### PR TITLE
Enhance view of long entity names (devices, assets): truncate instead of decreasing font size

### DIFF
--- a/lib/modules/asset/assets_base.dart
+++ b/lib/modules/asset/assets_base.dart
@@ -69,17 +69,15 @@ mixin AssetsBase on EntitiesBase<AssetInfo, PageLink> {
                         mainAxisAlignment: MainAxisAlignment.spaceBetween,
                         children: [
                           Flexible(
-                            child: FittedBox(
-                              fit: BoxFit.fitWidth,
-                              alignment: Alignment.centerLeft,
-                              child: Text(
-                                asset.name,
-                                style: const TextStyle(
-                                  color: Color(0xFF282828),
-                                  fontSize: 14,
-                                  fontWeight: FontWeight.w500,
-                                  height: 20 / 14,
-                                ),
+                            child: Text(
+                              asset.name,
+                              maxLines: 1,
+                              overflow: TextOverflow.ellipsis,
+                              style: const TextStyle(
+                                color: Color(0xFF282828),
+                                fontSize: 14,
+                                fontWeight: FontWeight.w500,
+                                height: 20 / 14,
                               ),
                             ),
                           ),
@@ -136,17 +134,15 @@ mixin AssetsBase on EntitiesBase<AssetInfo, PageLink> {
                   child: Column(
                     crossAxisAlignment: CrossAxisAlignment.start,
                     children: [
-                      FittedBox(
-                        fit: BoxFit.fitWidth,
-                        alignment: Alignment.centerLeft,
-                        child: Text(
-                          asset.name,
-                          style: const TextStyle(
-                            color: Color(0xFF282828),
-                            fontSize: 14,
-                            fontWeight: FontWeight.w500,
-                            height: 1.7,
-                          ),
+                      Text(
+                        asset.name,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
+                        style: const TextStyle(
+                          color: Color(0xFF282828),
+                          fontSize: 14,
+                          fontWeight: FontWeight.w500,
+                          height: 1.7,
                         ),
                       ),
                       Text(

--- a/lib/modules/device/devices_base.dart
+++ b/lib/modules/device/devices_base.dart
@@ -274,17 +274,15 @@ class _DeviceCardState extends State<DeviceCard> {
                                     children: [
                                       Flexible(
                                         fit: FlexFit.tight,
-                                        child: FittedBox(
-                                          fit: BoxFit.scaleDown,
-                                          alignment: Alignment.centerLeft,
-                                          child: Text(
-                                            widget.device.field('name')!,
-                                            style: const TextStyle(
-                                              color: Color(0xFF282828),
-                                              fontSize: 14,
-                                              fontWeight: FontWeight.w500,
-                                              height: 20 / 14,
-                                            ),
+                                        child: Text(
+                                          widget.device.field('name')!,
+                                          maxLines: 1,
+                                          overflow: TextOverflow.ellipsis,
+                                          style: const TextStyle(
+                                            color: Color(0xFF282828),
+                                            fontSize: 14,
+                                            fontWeight: FontWeight.w500,
+                                            height: 20 / 14,
                                           ),
                                         ),
                                       ),
@@ -445,11 +443,11 @@ class _DeviceCardState extends State<DeviceCard> {
                   mainAxisSize: MainAxisSize.min,
                   mainAxisAlignment: MainAxisAlignment.spaceBetween,
                   children: [
-                    FittedBox(
-                      fit: BoxFit.fitWidth,
-                      alignment: Alignment.centerLeft,
+                    Flexible(
                       child: Text(
                         widget.device.field('name')!,
+                        maxLines: 1,
+                        overflow: TextOverflow.ellipsis,
                         style: const TextStyle(
                           color: Color(0xFF282828),
                           fontSize: 14,


### PR DESCRIPTION
Long entity titles shrink to unreadable font sizes due to FittedBox scaling. Use fixed font size with ellipsis truncation instead.

**Before**
<img width="435" height="949" alt="image" src="https://github.com/user-attachments/assets/e99a7d00-849c-4f13-92ec-07f21312a553" />

**After**
<img width="435" height="949" alt="image" src="https://github.com/user-attachments/assets/a1e2d371-6a30-4c5e-aafe-9f128f4207ca" />
