### PR TITLE
fix: correct MFA token check to prevent permanent loading spinner on login

### DIFF
--- a/lib/core/auth/login/provider/login_provider.dart
+++ b/lib/core/auth/login/provider/login_provider.dart
@@ -69,7 +69,7 @@ class Login extends _$Login {
       final res = await _tbClient.login(LoginRequest(email, password));
       final user = _tbClient.getAuthUser();
       if (user != null &&
-          (user.isMfaConfigurationToken() || user.isMfaConfigurationToken())) {
+          (user.isMfaConfigurationToken() || user.isPreVerificationToken())) {
         return false;
       }
     } catch (e) {


### PR DESCRIPTION
## Summary

- `login()` was calling `isMfaConfigurationToken()` twice (copy-paste typo) instead of `isMfaConfigurationToken() || isPreVerificationToken()`
- For PRE_VERIFICATION users the guard always evaluated to `false`, so `login()` returned `true`
- This left `loading.value = true` and the full-screen spinner permanently visible after submitting credentials when MFA is required

## Test plan

- [ ] Enter email + password for an account with MFA enabled — spinner should hide after navigating to the MFA confirmation page
- [ ] Complete MFA flow — login succeeds as normal
- [ ] Go back from the MFA page — login page shows without a stuck spinner