### PR TITLE
feat: display entity label in device and asset list cards

### DIFF
--- a/lib/modules/asset/assets_base.dart
+++ b/lib/modules/asset/assets_base.dart
@@ -96,6 +96,22 @@ mixin AssetsBase on EntitiesBase<AssetInfo, PageLink> {
                           ),
                         ],
                       ),
+                      if (asset.label?.isNotEmpty == true)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            asset.label!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Color(0xFFAFAFAF),
+                              fontSize: 12,
+                              fontWeight: FontWeight.normal,
+                              fontStyle: FontStyle.italic,
+                              height: 16 / 12,
+                            ),
+                          ),
+                        ),
                       const SizedBox(height: 4),
                       Text(
                         asset.type,
@@ -145,6 +161,22 @@ mixin AssetsBase on EntitiesBase<AssetInfo, PageLink> {
                           height: 1.7,
                         ),
                       ),
+                      if (asset.label?.isNotEmpty == true)
+                        Padding(
+                          padding: const EdgeInsets.only(top: 2),
+                          child: Text(
+                            asset.label!,
+                            maxLines: 1,
+                            overflow: TextOverflow.ellipsis,
+                            style: const TextStyle(
+                              color: Color(0xFFAFAFAF),
+                              fontSize: 12,
+                              fontWeight: FontWeight.normal,
+                              fontStyle: FontStyle.italic,
+                              height: 16 / 12,
+                            ),
+                          ),
+                        ),
                       Text(
                         asset.type,
                         style: const TextStyle(

--- a/lib/modules/device/devices_base.dart
+++ b/lib/modules/device/devices_base.dart
@@ -267,6 +267,7 @@ class _DeviceCardState extends State<DeviceCard> {
                             Flexible(
                               fit: FlexFit.tight,
                               child: Column(
+                                crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
                                   Row(
                                     mainAxisAlignment:
@@ -302,6 +303,22 @@ class _DeviceCardState extends State<DeviceCard> {
                                       ),
                                     ],
                                   ),
+                                  if (widget.device.field('label')?.isNotEmpty == true)
+                                    Padding(
+                                      padding: const EdgeInsets.only(top: 2),
+                                      child: Text(
+                                        widget.device.field('label')!,
+                                        maxLines: 1,
+                                        overflow: TextOverflow.ellipsis,
+                                        style: const TextStyle(
+                                          color: Color(0xFFAFAFAF),
+                                          fontSize: 12,
+                                          fontWeight: FontWeight.normal,
+                                          fontStyle: FontStyle.italic,
+                                          height: 16 / 12,
+                                        ),
+                                      ),
+                                    ),
                                   const SizedBox(height: 4),
                                   Row(
                                     mainAxisAlignment:
@@ -458,6 +475,22 @@ class _DeviceCardState extends State<DeviceCard> {
                     ),
                   ],
                 ),
+                if (widget.device.field('label')?.isNotEmpty == true)
+                  Padding(
+                    padding: const EdgeInsets.only(top: 2),
+                    child: Text(
+                      widget.device.field('label')!,
+                      maxLines: 1,
+                      overflow: TextOverflow.ellipsis,
+                      style: const TextStyle(
+                        color: Color(0xFFAFAFAF),
+                        fontSize: 12,
+                        fontWeight: FontWeight.normal,
+                        fontStyle: FontStyle.italic,
+                        height: 16 / 12,
+                      ),
+                    ),
+                  ),
                 const SizedBox(height: 4),
                 Row(
                   mainAxisSize: MainAxisSize.min,


### PR DESCRIPTION
## Summary
- Display the `label` field as secondary italic text below the entity name in device and asset list cards
- Label is only shown when non-empty, preserving existing layout for entities without labels
- Applies to both full list cards and compact widget cards for devices and assets

Closes #216

## Screenshots

> Screenshots to be added — please drag and drop images into this description via GitHub web UI.

## Test plan
- [ ] Verify label appears below device name when label is set
- [ ] Verify no extra space when label is empty
- [ ] Verify label truncates with ellipsis for long text
- [ ] Check both "All devices" and device profile filtered views
- [ ] Check asset list cards show label similarly