### PR TITLE
fix: alarm comment crash and wrong display format

### DIFF
--- a/lib/modules/alarm/data/datasource/details/alarm_details_datasource.dart
+++ b/lib/modules/alarm/data/datasource/details/alarm_details_datasource.dart
@@ -9,13 +9,8 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
   @override
   Future<PageData<AlarmCommentInfo>> fetchAlarmComments(
     AlarmCommentsQuery query,
-  ) async {
-    final result =
-        await thingsboardClient.getAlarmService().getAlarmComments(query);
-    for (final item in result.data) {
-      _parseComment(item);
-    }
-    return result;
+  ) {
+    return thingsboardClient.getAlarmService().getAlarmComments(query);
   }
 
   @override
@@ -32,12 +27,10 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
   Future<AlarmCommentInfo> postComment(
     AlarmId alarmId, {
     required String comment,
-  }) async {
-    final result = await thingsboardClient.getAlarmService().postAlarmComment(
+  }) {
+    return thingsboardClient.getAlarmService().postAlarmComment(
       AlarmComment(null, null, alarmId, null, AlarmCommentType.OTHER, {'text': comment}, null),
     );
-    _parseComment(result);
-    return result;
   }
 
   @override
@@ -53,12 +46,10 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
     AlarmId alarmId, {
     required String id,
     required String comment,
-  }) async {
-    final result = await thingsboardClient.getAlarmService().postAlarmComment(
+  }) {
+    return thingsboardClient.getAlarmService().postAlarmComment(
       AlarmComment(id, null, alarmId, null, AlarmCommentType.OTHER, {'text': comment, 'edited': 'true'}, null),
     );
-    _parseComment(result);
-    return result;
   }
 
   @override
@@ -74,22 +65,5 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
   @override
   Future<AlarmInfo> unassignAlarm(String alarmId) {
     return thingsboardClient.getAlarmService().unassignAlarm(alarmId);
-  }
-
-  void _parseComment(AlarmComment alarmComment) {
-    if (alarmComment.comment is Map) {
-      alarmComment.comment = AlarmCommentJsonNode.fromJson(
-        Map<String, dynamic>.from(alarmComment.comment as Map),
-      );
-    } else if (alarmComment.comment is String) {
-      alarmComment.comment = AlarmCommentJsonNode(
-        text: alarmComment.comment as String,
-        subtype: null,
-        userId: null,
-        edited: false,
-        editedOn: null,
-        assigneeId: null,
-      );
-    }
   }
 }

--- a/lib/modules/alarm/data/datasource/details/alarm_details_datasource.dart
+++ b/lib/modules/alarm/data/datasource/details/alarm_details_datasource.dart
@@ -9,8 +9,13 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
   @override
   Future<PageData<AlarmCommentInfo>> fetchAlarmComments(
     AlarmCommentsQuery query,
-  ) {
-    return thingsboardClient.getAlarmService().getAlarmComments(query);
+  ) async {
+    final result =
+        await thingsboardClient.getAlarmService().getAlarmComments(query);
+    for (final item in result.data) {
+      _parseComment(item);
+    }
+    return result;
   }
 
   @override
@@ -27,11 +32,12 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
   Future<AlarmCommentInfo> postComment(
     AlarmId alarmId, {
     required String comment,
-  }) {
-    return thingsboardClient.getAlarmService().postAlarmComment(
-      AlarmComment(null, null, alarmId, null, AlarmCommentType.OTHER, comment, null),
-    
+  }) async {
+    final result = await thingsboardClient.getAlarmService().postAlarmComment(
+      AlarmComment(null, null, alarmId, null, AlarmCommentType.OTHER, {'text': comment}, null),
     );
+    _parseComment(result);
+    return result;
   }
 
   @override
@@ -47,10 +53,12 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
     AlarmId alarmId, {
     required String id,
     required String comment,
-  }) {
-    return thingsboardClient.getAlarmService().postAlarmComment(
-      AlarmComment(id, null, alarmId, null, AlarmCommentType.OTHER, comment, null)
+  }) async {
+    final result = await thingsboardClient.getAlarmService().postAlarmComment(
+      AlarmComment(id, null, alarmId, null, AlarmCommentType.OTHER, {'text': comment, 'edited': 'true'}, null),
     );
+    _parseComment(result);
+    return result;
   }
 
   @override
@@ -66,5 +74,22 @@ class AlarmDetailsDatasource implements IAlarmDetailsDatasource {
   @override
   Future<AlarmInfo> unassignAlarm(String alarmId) {
     return thingsboardClient.getAlarmService().unassignAlarm(alarmId);
+  }
+
+  void _parseComment(AlarmComment alarmComment) {
+    if (alarmComment.comment is Map) {
+      alarmComment.comment = AlarmCommentJsonNode.fromJson(
+        Map<String, dynamic>.from(alarmComment.comment as Map),
+      );
+    } else if (alarmComment.comment is String) {
+      alarmComment.comment = AlarmCommentJsonNode(
+        text: alarmComment.comment as String,
+        subtype: null,
+        userId: null,
+        edited: false,
+        editedOn: null,
+        assigneeId: null,
+      );
+    }
   }
 }

--- a/lib/modules/alarm/presentation/widgets/activity/alarm_edit_comment_textfield.dart
+++ b/lib/modules/alarm/presentation/widgets/activity/alarm_edit_comment_textfield.dart
@@ -78,7 +78,7 @@ class _AlarmEditCommentState extends State<AlarmEditCommentTextField> {
 
   @override
   void initState() {
-    textController.text = widget.commentToEdit.comment.toString();
+    textController.text = (widget.commentToEdit.comment as AlarmCommentJsonNode).text;
     super.initState();
   }
 

--- a/lib/modules/alarm/presentation/widgets/activity/system_activity_widget.dart
+++ b/lib/modules/alarm/presentation/widgets/activity/system_activity_widget.dart
@@ -24,7 +24,7 @@ class SystemActivityWidget extends StatelessWidget {
           ),
         ),
         Text(
-          activity.comment.toString(),
+          (activity.comment as AlarmCommentJsonNode).text,
           style: TbTextStyles.bodyLarge.copyWith(
             color: Colors.black.withValues(alpha: .54),
           ),

--- a/lib/modules/alarm/presentation/widgets/activity/user_comment_widget.dart
+++ b/lib/modules/alarm/presentation/widgets/activity/user_comment_widget.dart
@@ -163,7 +163,7 @@ class _UserCommentState extends State<UserCommentWidget> {
                 ),
                 const SizedBox(width: 4),
                 Visibility(
-                  visible: widget.activity.comment.edited == true,
+                  visible: (widget.activity.comment as AlarmCommentJsonNode).edited,
                   child: Text(
                     ' ${S.of(context).edited}',
                     style: TbTextStyles.bodyMedium.copyWith(
@@ -174,7 +174,7 @@ class _UserCommentState extends State<UserCommentWidget> {
               ],
             ),
             Text(
-              widget.activity.comment.toString(),
+              (widget.activity.comment as AlarmCommentJsonNode).text,
               style: TbTextStyles.bodyLarge.copyWith(
                 color: Colors.black.withValues(alpha: .54),
               ),


### PR DESCRIPTION
## Summary

Fixes a crash when viewing alarm comments and a display issue where system activity entries (assignments, status changes) were rendered as raw JSON `{text: ..., subtype: ..., userName: ...}` instead of the actual message.

## Root cause

The ThingsBoard API expects the alarm comment payload as a JSON object (`{"text": "..."}`), but the mobile app was posting comments as plain `String` values. The server tolerates both formats on write, but returns whatever was stored:

- **System-generated and web-posted comments** → returned as `Map`
- **Mobile-posted comments (legacy)** → returned as `String`

`AlarmComment.comment` is typed as `dynamic` in the client library, so widgets calling `.edited` / accessing the full text assumed a typed object and crashed with `NoSuchMethodError: Class 'String' has no instance getter 'edited'` whenever they encountered a legacy mobile comment. System activity widgets called `toString()` on the map, producing the raw `{text: ..., subtype: ...}` output.

## Changes

### Flutter app (`flutter_thingsboard_app`)
- **`alarm_details_datasource.dart`** — post/update now send the API-expected `{'text': comment}` payload instead of a raw string. Removed `_parseComment` workaround since parsing is now handled in the client library.
- **Activity widgets** (`user_comment_widget.dart`, `system_activity_widget.dart`, `alarm_edit_comment_textfield.dart`) — use `(comment as AlarmCommentJsonNode).text` / `.edited` instead of `dynamic` access.

### Dart client library (`thingsboard_client`)
- See companion PR: https://github.com/thingsboard/dart_thingsboard_client/pull/61
- **`AlarmComment.fromJson`** — parses `comment` field into `AlarmCommentJsonNode` automatically (handles both `Map` and legacy `String` formats).
- **`AlarmComment.toJson`** — serializes `AlarmCommentJsonNode` back to a Map for the API.

> **Note:** This PR depends on thingsboard/dart_thingsboard_client#61. Once that client library change is published, the datasource in this PR is a clean pass-through.

## Test plan

- [ ] Post a new comment on an alarm — renders correctly, no crash
- [ ] Edit an existing comment — edit dialog pre-populates with the text, "edited" label appears after save
- [ ] View an alarm that has a legacy mobile-posted comment (stored as raw string) — renders correctly, no crash
- [ ] View an alarm with system activity (assignment/unassignment, status change) — shows the human-readable message, not the raw JSON