### PR TITLE
feat: multi-select notifications with batch delete and mark as read

### DIFF
--- a/lib/generated/intl/messages_ar.dart
+++ b/lib/generated/intl/messages_ar.dart
@@ -46,49 +46,60 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'لوحة معلومات', other: 'لوحات معلومات')}";
 
   static String m9(count) =>
+      "${Intl.plural(count, one: 'حذف إشعار واحد؟', other: 'حذف ${count} إشعارات؟')}";
+
+  static String m10(count) =>
       "${Intl.plural(count, one: 'جهاز', other: 'أجهزة')}";
 
-  static String m10(count) => "رمز من ${count} أرقام";
+  static String m11(count) => "رمز من ${count} أرقام";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "تم إرسال رمز أمني إلى بريدك الإلكتروني على العنوان ${contact}.";
 
-  static String m12(e) => "حدث خطأ: ${e}";
+  static String m13(e) => "حدث خطأ: ${e}";
 
-  static String m13(error) => "خطأ في إرسال الرمز: ${error}";
+  static String m14(error) => "خطأ في إرسال الرمز: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: 'فشلت عملية واحدة', other: 'فشلت ${count} عمليات')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'وضع علامة مقروء لإشعار واحد؟', other: 'وضع علامة مقروء لـ ${count} إشعارات؟')}";
+
+  static String m17(count) => "${count} محدد";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'إشعار', other: 'إشعارات')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى فتح إعدادات التطبيق ومنح الأذونات والضغط على \"حاول مرة أخرى\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "ليس لديك أذونات كافية لـ \"${permissions}\" للمتابعة. يرجى منح الأذونات المطلوبة والضغط على \"حاول مرة أخرى\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "أدخل رقم PIN الخاص بـ ${deviceName} لتأكيد إثبات الحيازة";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "إعادة إرسال الرمز في ${Intl.plural(time, one: 'ثانية واحدة', other: '${time} ثواني')}";
 
-  static String m19(name) => "المسار غير محدد: ${name}";
+  static String m23(name) => "المسار غير محدد: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'البحث عن مستخدم', other: 'البحث عن مستخدمين')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "تم إرسال رمز أمني إلى هاتفك على الرقم ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "تعذر الاتصال بـ Wi-Fi لأن الجهاز ${name} لم يجد شبكات";
 
-  static String m23(version) => "تحديث إلى ${version}";
+  static String m27(version) => "تحديث إلى ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "لمتابعة إعداد جهازك ${deviceName}، يرجى تقديم بيانات اعتماد الشبكة الخاصة بك.";
 
-  static String m25(network) => "أدخل كلمة المرور لـ ${network}";
+  static String m29(network) => "أدخل كلمة المرور لـ ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -342,6 +353,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("حذف"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("حذف الحساب"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("حذف التعليق"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("التفاصيل"),
     "deviceList": MessageLookupByLibrary.simpleMessage("قائمة الأجهزة"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -352,8 +364,8 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "deviceProfile": MessageLookupByLibrary.simpleMessage("ملف تعريف الجهاز"),
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage("تهيئة الجهاز"),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("تجاهل التغييرات"),
     "domain": MessageLookupByLibrary.simpleMessage("النطاق"),
     "done": MessageLookupByLibrary.simpleMessage("تم"),
@@ -362,7 +374,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("تحرير"),
     "edited": MessageLookupByLibrary.simpleMessage("محرر"),
     "email": MessageLookupByLibrary.simpleMessage("البريد الإلكتروني"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "رمز البريد الإلكتروني",
     ),
@@ -398,8 +410,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("نوع الكيان"),
     "entityView": MessageLookupByLibrary.simpleMessage("عرض الكيان"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("أوروبا"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("فرانكفورت"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -414,6 +426,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "فشل في تحميل القائمة",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("تفاصيل الفشل"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "حدث خطأ فادح في التطبيق:",
@@ -477,6 +490,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("رئيسي"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("تحديد الكل كمقروء"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("تحديد كمقروء"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("متري"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "الرمز الاحتياطي",
@@ -497,6 +511,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "يجب تكوين لوحة المعلومات المحمولة في ملف تعريف الجهاز!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("المزيد"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("كلمة المرور الجديدة"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "تأكيد كلمة المرور الجديدة",
@@ -537,12 +552,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "قالب الإشعار",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("عميل OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "فتح إعدادات التطبيق",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "افتح الإعدادات ومنح الوصول للكاميرا للمتابعة",
@@ -577,7 +592,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "تم تغيير كلمة المرور بنجاح",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("الأذونات"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("الهاتف"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "رقم الهاتف غير صالح",
@@ -600,7 +615,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "يرجى مسح رمز QR على جهازك",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ نوع تنبيه"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("الرمز البريدي"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("سياسة الخصوصية"),
     "profile": MessageLookupByLibrary.simpleMessage("الملف الشخصي"),
@@ -629,7 +644,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("إعادة إرسال"),
     "resendCode": MessageLookupByLibrary.simpleMessage("إعادة إرسال الرمز"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("إعادة تعيين"),
     "retry": MessageLookupByLibrary.simpleMessage("إعادة المحاولة"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -638,7 +653,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "عد إلى التطبيق واضغط على زر جاهز",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("سلسلة القواعد"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("عقدة القواعد"),
@@ -646,9 +661,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("مسح رمز QR"),
     "search": MessageLookupByLibrary.simpleMessage("بحث"),
     "searchResults": MessageLookupByLibrary.simpleMessage("نتائج البحث"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("ثواني"),
     "security": MessageLookupByLibrary.simpleMessage("الأمان"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("تحديد الكل المحمّل"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("اختيار البلد"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("حدد المنطقة"),
     "selectUser": MessageLookupByLibrary.simpleMessage("اختيار المستخدمين"),
@@ -672,7 +688,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("الخطورة"),
     "signIn": MessageLookupByLibrary.simpleMessage("تسجيل الدخول"),
     "signUp": MessageLookupByLibrary.simpleMessage("التسجيل"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("رمز SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "في المرة القادمة التي تسجل فيها الدخول، سيُطلب منك إدخال رمز الأمان المرسل إلى رقم الهاتف",
@@ -732,7 +748,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "تعذر الاتصال بالجهاز",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "غير قادر على استخدام الكاميرا",
     ),
@@ -746,7 +762,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("تحديث"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("تحديث مطلوب"),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("رابط"),
     "user": MessageLookupByLibrary.simpleMessage("المستخدم"),
     "username": MessageLookupByLibrary.simpleMessage("اسم المستخدم"),
@@ -769,9 +785,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("تحذير"),
     "widgetType": MessageLookupByLibrary.simpleMessage("نوع الأداة"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("حزمة الأدوات"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("كلمة مرور Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("نعم"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("نعم، تعطيل"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("نعم، تجاهل"),

--- a/lib/generated/intl/messages_da_DK.dart
+++ b/lib/generated/intl/messages_da_DK.dart
@@ -47,50 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Enhed', other: 'Enheder')}";
+      "${Intl.plural(count, one: 'Slet 1 notifikation?', other: 'Slet ${count} notifikationer?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Enhed', other: 'Enheder')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'cifret', other: 'cifre')} kode";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "En sikkerhedskode er blevet sendt til din emailadresse på ${contact}.";
 
-  static String m12(e) => "Fejl opstod: ${e}";
+  static String m13(e) => "Fejl opstod: ${e}";
 
-  static String m13(error) => "Fejl ved afsendelse af kode: ${error}";
+  static String m14(error) => "Fejl ved afsendelse af kode: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 handling mislykkedes', other: '${count} handlinger mislykkedes')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'Markér 1 notifikation som læst?', other: 'Markér ${count} notifikationer som læst?')}";
+
+  static String m17(count) => "${count} valgt";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notifikation', other: 'Notifikationer')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Åbn app-indstillingerne, giv tilladelser og tryk på \"Prøv igen\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "Du har ikke tilstrækkelige tilladelser til \"${permissions}\" for at fortsætte. Giv de nødvendige tilladelser og tryk på \"Prøv igen\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Indtast PIN-kode for ${deviceName} for at bekræfte ejerskab";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Send kode igen om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m19(name) => "Rute ikke defineret: ${name}";
+  static String m23(name) => "Rute ikke defineret: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Søg bruger', other: 'Søg brugere')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "En sikkerhedskode er blevet sendt til din telefon på ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Kan ikke oprette forbindelse til Wi-Fi, fordi netværk ikke blev fundet af enheden ${name}";
 
-  static String m23(version) => "Opdater til ${version}";
+  static String m27(version) => "Opdater til ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "For at fortsætte opsætningen af din enhed ${deviceName}, skal du angive netværkets legitimationsoplysninger.";
 
-  static String m25(network) => "Indtast adgangskode til ${network}";
+  static String m29(network) => "Indtast adgangskode til ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -348,6 +359,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Slet"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Slet konto"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Slet kommentar"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Detaljer"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Enhedsliste"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -360,8 +372,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Enhedsklargøring",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Kassér ændringer"),
     "domain": MessageLookupByLibrary.simpleMessage("Domæne"),
     "done": MessageLookupByLibrary.simpleMessage("Færdig"),
@@ -370,7 +382,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Rediger"),
     "edited": MessageLookupByLibrary.simpleMessage("Redigeret"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Email-kode"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ugyldigt emailformat.",
@@ -404,8 +416,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Enhedstype"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entitetsvisning"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -420,6 +432,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke indlæse listen",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("Fejldetaljer"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "Fatal applikationsfejl opstod:",
@@ -485,6 +498,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Markér alle som læst",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Markér som læst"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisk"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage("Backupkode"),
     "mfaProviderEmail": MessageLookupByLibrary.simpleMessage("Email"),
@@ -501,6 +515,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashboard skal konfigureres i enhedsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mere"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Ny adgangskode"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekræft ny adgangskode",
@@ -549,12 +564,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notifikationsskabelon",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åbn app-indstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åbn indstillinger og giv adgang til kameraet for at fortsætte",
@@ -589,7 +604,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Adgangskoden blev ændret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tilladelser"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldigt",
@@ -616,7 +631,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan venligst QR-koden på din enhed",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privatlivspolitik"),
     "profile": MessageLookupByLibrary.simpleMessage("Profil"),
@@ -645,7 +660,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gensend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send kode igen"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Nulstil"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -654,7 +669,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Vend tilbage til appen og tryk på Klar-knappen",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkæde"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknude"),
@@ -662,9 +677,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("Scan QR-kode"),
     "search": MessageLookupByLibrary.simpleMessage("Søg"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søgeresultater"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhed"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Vælg alle indlæste"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Vælg land"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Vælg region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Vælg brugere"),
@@ -688,7 +704,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighed"),
     "signIn": MessageLookupByLibrary.simpleMessage("Log ind"),
     "signUp": MessageLookupByLibrary.simpleMessage("Tilmeld"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Næste gang du logger ind, vil du blive bedt om at indtaste sikkerhedskoden, der sendes til telefonnummeret",
@@ -752,7 +768,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke oprette forbindelse til enhed",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruge kameraet",
     ),
@@ -768,7 +784,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Opdatering påkrævet",
     ),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Bruger"),
     "username": MessageLookupByLibrary.simpleMessage("brugernavn"),
@@ -793,9 +809,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-pakke"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi adgangskode"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, kassér"),

--- a/lib/generated/intl/messages_de_DE.dart
+++ b/lib/generated/intl/messages_de_DE.dart
@@ -47,50 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Gerät', other: 'Geräte')}";
+      "${Intl.plural(count, one: '1 Benachrichtigung löschen?', other: '${count} Benachrichtigungen löschen?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Gerät', other: 'Geräte')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'stelliger', other: 'stelliger')} Code";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Ein Sicherheitscode wurde an Ihre E-Mail-Adresse unter ${contact} gesendet.";
 
-  static String m12(e) => "Fehler aufgetreten: ${e}";
+  static String m13(e) => "Fehler aufgetreten: ${e}";
 
-  static String m13(error) => "Fehler beim Senden des Codes: ${error}";
+  static String m14(error) => "Fehler beim Senden des Codes: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 Vorgang fehlgeschlagen', other: '${count} Vorgänge fehlgeschlagen')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: '1 Benachrichtigung als gelesen markieren?', other: '${count} Benachrichtigungen als gelesen markieren?')}";
+
+  static String m17(count) => "${count} ausgewählt";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Benachrichtigung', other: 'Benachrichtigungen')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte öffnen Sie die App-Einstellungen, erteilen Sie die Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "Sie haben nicht genügend Berechtigungen für \"${permissions}\". Bitte erteilen Sie die erforderlichen Berechtigungen und tippen Sie auf \"Erneut versuchen\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Geben Sie die PIN von ${deviceName} ein, um den Besitznachweis zu bestätigen";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Code erneut senden in ${Intl.plural(time, one: '1 Sekunde', other: '${time} Sekunden')}";
 
-  static String m19(name) => "Route nicht definiert: ${name}";
+  static String m23(name) => "Route nicht definiert: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Benutzer suchen', other: 'Benutzer suchen')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "Ein Sicherheitscode wurde an Ihr Telefon unter ${contact} gesendet.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "WLAN-Verbindung nicht möglich, da das Gerät ${name} keine Netzwerke gefunden hat";
 
-  static String m23(version) => "Aktualisieren auf ${version}";
+  static String m27(version) => "Aktualisieren auf ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "Um die Einrichtung Ihres Geräts ${deviceName} fortzusetzen, geben Sie bitte die Zugangsdaten Ihres Netzwerks ein.";
 
-  static String m25(network) => "Passwort für ${network} eingeben";
+  static String m29(network) => "Passwort für ${network} eingeben";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -358,6 +369,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Löschen"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Konto löschen"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Kommentar löschen"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Details"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Geräteliste"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -370,8 +382,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Gerätebereitstellung",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage(
       "Änderungen verwerfen",
     ),
@@ -382,7 +394,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Bearbeiten"),
     "edited": MessageLookupByLibrary.simpleMessage("Bearbeitet"),
     "email": MessageLookupByLibrary.simpleMessage("E-Mail"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("E-Mail-Code"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ungültiges E-Mail-Format.",
@@ -416,8 +428,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Entitätstyp"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entitätsansicht"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -432,6 +444,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Liste konnte nicht geladen werden",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("Fehlerdetails"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "Schwerwiegender Anwendungsfehler aufgetreten:",
@@ -497,6 +510,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Alle als gelesen markieren",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Als gelesen markieren"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisch"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Backup-Code",
@@ -515,6 +529,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Das mobile Dashboard sollte im Geräteprofil konfiguriert werden!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mehr"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Neues Passwort"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Neues Passwort bestätigen",
@@ -563,12 +578,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Benachrichtigungsvorlage",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-Client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-Einstellungen öffnen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Öffnen Sie die Einstellungen und gewähren Sie Kamerazugriff, um fortzufahren",
@@ -603,7 +618,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passwort erfolgreich geändert",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Berechtigungen"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer ist ungültig",
@@ -630,7 +645,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Bitte scannen Sie den QR-Code auf Ihrem Gerät",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtyp"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("PLZ / Postleitzahl"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Datenschutzerklärung",
@@ -663,7 +678,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Erneut senden"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Code erneut senden"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Zurücksetzen"),
     "retry": MessageLookupByLibrary.simpleMessage("Erneut versuchen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -672,7 +687,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Kehren Sie zur App zurück und tippen Sie auf Bereit",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkette"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknoten"),
@@ -680,9 +695,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("QR-Code scannen"),
     "search": MessageLookupByLibrary.simpleMessage("Suchen"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Suchergebnisse"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("Sekunden"),
     "security": MessageLookupByLibrary.simpleMessage("Sicherheit"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Alle geladenen auswählen",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Land auswählen"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Region auswählen"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Benutzer auswählen"),
@@ -706,7 +724,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Schweregrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Anmelden"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrieren"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-Code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Bei der nächsten Anmeldung werden Sie aufgefordert, den Sicherheitscode einzugeben, der an die Telefonnummer gesendet wird",
@@ -772,7 +790,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Verbindung zum Gerät nicht möglich",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kamera kann nicht verwendet werden",
     ),
@@ -788,7 +806,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aktualisierung erforderlich",
     ),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Benutzer"),
     "username": MessageLookupByLibrary.simpleMessage("Benutzername"),
@@ -813,9 +831,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warnung"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget-Typ"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widget-Paket"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("WLAN-Passwort"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktivieren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerfen"),

--- a/lib/generated/intl/messages_el_GR.dart
+++ b/lib/generated/intl/messages_el_GR.dart
@@ -46,50 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Πίνακας ελέγχου', other: 'Πίνακες ελέγχου')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Συσκευή', other: 'Συσκευές')}";
+      "${Intl.plural(count, one: 'Διαγραφή 1 ειδοποίησης;', other: 'Διαγραφή ${count} ειδοποιήσεων;')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Συσκευή', other: 'Συσκευές')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'ψήφιος', other: 'ψήφιος')} κωδικός";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Ένας κωδικός ασφαλείας έχει σταλεί στο email σας στη διεύθυνση ${contact}.";
 
-  static String m12(e) => "Παρουσιάστηκε σφάλμα: ${e}";
+  static String m13(e) => "Παρουσιάστηκε σφάλμα: ${e}";
 
-  static String m13(error) => "Σφάλμα αποστολής κωδικού: ${error}";
+  static String m14(error) => "Σφάλμα αποστολής κωδικού: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 ενέργεια απέτυχε', other: '${count} ενέργειες απέτυχαν')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'Σήμανση 1 ειδοποίησης ως αναγνωσμένης;', other: 'Σήμανση ${count} ειδοποιήσεων ως αναγνωσμένων;')}";
+
+  static String m17(count) => "${count} επιλεγμένα";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Ειδοποίηση', other: 'Ειδοποιήσεις')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Ανοίξτε τις ρυθμίσεις της εφαρμογής, παραχωρήστε τα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "Δεν έχετε επαρκή δικαιώματα για \"${permissions}\" για να συνεχίσετε. Παρακαλώ δώστε τα απαραίτητα δικαιώματα και πατήστε \"Δοκιμάστε ξανά\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Εισαγάγετε το PIN της συσκευής ${deviceName} για επιβεβαίωση ιδιοκτησίας";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Επανάληψη αποστολής σε ${Intl.plural(time, one: '1 δευτερόλεπτο', other: '${time} δευτερόλεπτα')}";
 
-  static String m19(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
+  static String m23(name) => "Η διαδρομή δεν έχει οριστεί: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Αναζήτηση χρήστη', other: 'Αναζήτηση χρηστών')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "Ένας κωδικός ασφαλείας έχει σταλεί στο τηλέφωνό σας στο ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Αδυναμία σύνδεσης στο Wi-Fi επειδή η συσκευή ${name} δεν βρήκε δίκτυα";
 
-  static String m23(version) => "Ενημέρωση σε ${version}";
+  static String m27(version) => "Ενημέρωση σε ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "Για να συνεχίσετε τη ρύθμιση της συσκευής ${deviceName}, παρακαλώ δώστε τα διαπιστευτήρια του δικτύου σας.";
 
-  static String m25(network) =>
+  static String m29(network) =>
       "Εισαγάγετε τον κωδικό για το δίκτυο ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
@@ -376,6 +387,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Διαγραφή λογαριασμού",
     ),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Διαγραφή σχολίου"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Λεπτομέρειες"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Λίστα συσκευών"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -388,8 +400,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Διαμόρφωση συσκευής",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Απόρριψη αλλαγών"),
     "domain": MessageLookupByLibrary.simpleMessage("Τομέας"),
     "done": MessageLookupByLibrary.simpleMessage("Ολοκληρώθηκε"),
@@ -398,7 +410,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Επεξεργασία"),
     "edited": MessageLookupByLibrary.simpleMessage("Επεξεργασμένο"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "Κωδικός email",
     ),
@@ -436,8 +448,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Τύπος οντότητας"),
     "entityView": MessageLookupByLibrary.simpleMessage("Προβολή οντότητας"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Ευρώπη"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Φρανκφούρτη"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -452,6 +464,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Αποτυχία φόρτωσης της λίστας",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage(
       "Λεπτομέρειες αποτυχίας",
     ),
@@ -523,6 +536,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "markAsRead": MessageLookupByLibrary.simpleMessage(
       "Σήμανση ως αναγνωσμένο",
     ),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Μετρικό"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Εφεδρικός κωδικός",
@@ -543,6 +557,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Ο πίνακας ελέγχου κινητού πρέπει να ρυθμιστεί στο προφίλ συσκευής!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Περισσότερα"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage(
       "Νέος κωδικός πρόσβασης",
     ),
@@ -593,12 +608,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Πρότυπο ειδοποίησης",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Πελάτης OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Άνοιγμα ρυθμίσεων εφαρμογής",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ανοίξτε τις ρυθμίσεις και δώστε πρόσβαση στην κάμερα για να συνεχίσετε",
@@ -631,7 +646,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Ο κωδικός πρόσβασης άλλαξε με επιτυχία",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Δικαιώματα"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Τηλέφωνο"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Ο αριθμός τηλεφώνου δεν είναι έγκυρος",
@@ -658,7 +673,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Σαρώστε τον κωδικό QR στη συσκευή σας",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Τύπος συναγερμού"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Ταχυδρομικός κώδικας"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Πολιτική απορρήτου"),
     "profile": MessageLookupByLibrary.simpleMessage("Προφίλ"),
@@ -689,7 +704,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Επανάληψη αποστολής κωδικού",
     ),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Επαναφορά"),
     "retry": MessageLookupByLibrary.simpleMessage("Επανάληψη"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -698,7 +713,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Επιστρέψτε στην εφαρμογή και πατήστε το κουμπί Έτοιμο",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Αλυσίδα κανόνων"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Κόμβος κανόνων"),
@@ -708,9 +723,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Αποτελέσματα αναζήτησης",
     ),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("δευτερόλεπτα"),
     "security": MessageLookupByLibrary.simpleMessage("Ασφάλεια"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Επιλογή όλων των φορτωμένων",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Επιλογή χώρας"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Επιλογή περιοχής"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Επιλέξτε χρήστες"),
@@ -734,7 +752,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Σοβαρότητα"),
     "signIn": MessageLookupByLibrary.simpleMessage("Σύνδεση"),
     "signUp": MessageLookupByLibrary.simpleMessage("Εγγραφή"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Κωδικός SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Την επόμενη φορά που θα συνδεθείτε, θα σας ζητηθεί ο κωδικός ασφαλείας που θα σταλεί στο τηλέφωνο",
@@ -800,7 +818,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία σύνδεσης στη συσκευή",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Αδυναμία χρήσης κάμερας",
     ),
@@ -816,7 +834,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Απαιτείται ενημέρωση",
     ),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Χρήστης"),
     "username": MessageLookupByLibrary.simpleMessage("όνομα χρήστη"),
@@ -843,9 +861,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Προειδοποίηση"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Τύπος widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Πακέτο widgets"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Κωδικός Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ναι"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage(
       "Ναι, απενεργοποίηση",

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -46,50 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Device', other: 'Devices')}";
+      "${Intl.plural(count, one: 'Delete 1 notification?', other: 'Delete ${count} notifications?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Device', other: 'Devices')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'digit', other: 'digits')} code";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "A security code has been sent to your email address at ${contact}.";
 
-  static String m12(e) => "Error occured: ${e}";
+  static String m13(e) => "Error occured: ${e}";
 
-  static String m13(error) => "Error sending code: ${error}";
+  static String m14(error) => "Error sending code: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 operation failed', other: '${count} operations failed')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'Mark 1 notification as read?', other: 'Mark ${count} notifications as read?')}";
+
+  static String m17(count) => "${count} selected";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please open app settings, grant permissions and trap \"Try Again\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "You don\'t have enough permissions for \"${permissions}\" to proceed. Please grant the required permissions and tap \"Try Again\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Enter PIN of ${deviceName} to confirm proof of possession";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Resend code in ${Intl.plural(time, one: '1 second', other: '${time} seconds')}";
 
-  static String m19(name) => "Route not defined: ${name}";
+  static String m23(name) => "Route not defined: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Search user', other: 'Search users')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "A security code has been sent to your phone at ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Unable connect to Wi-Fi because networks wasn\'t found by device ${name}";
 
-  static String m23(version) => "Update to ${version}";
+  static String m27(version) => "Update to ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "To continue setup of your device ${deviceName}, please provide your Network\'s credentials.";
 
-  static String m25(network) => "Enter password for ${network}";
+  static String m29(network) => "Enter password for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -345,6 +356,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Delete"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Delete account"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Delete comment"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Details"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Device list"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -357,8 +369,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Device provisioning",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Discard changes"),
     "domain": MessageLookupByLibrary.simpleMessage("Domain"),
     "done": MessageLookupByLibrary.simpleMessage("Done"),
@@ -367,7 +379,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Edit"),
     "edited": MessageLookupByLibrary.simpleMessage("Edited"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Email code"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Invalid email format.",
@@ -401,8 +413,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Entity Type"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entity view"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europe"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -417,6 +429,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Failed to load the list",
     ),
+    "failedToPerformOperation": m15,
     "failedToSaveImage": MessageLookupByLibrary.simpleMessage(
       "Failed to save image",
     ),
@@ -484,6 +497,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("Major"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("Mark all as read"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Mark as read"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metric"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Backup code",
@@ -504,6 +518,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobile dashboard should be configured in device profile!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("More"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("New password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirm new password",
@@ -555,12 +570,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Notification template",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Oauth2 client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Open app settings",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open settings and grant access to camera to continue",
@@ -593,7 +608,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password successfully changed",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permissions"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Phone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("Phone is invalid"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage(
@@ -618,7 +633,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Please scan QR code on your device",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarm type"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Zip / Postal Code"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacy Policy"),
     "profile": MessageLookupByLibrary.simpleMessage("Profile"),
@@ -647,7 +662,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Resend"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Resend code"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Reset"),
     "retry": MessageLookupByLibrary.simpleMessage("Retry"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -656,7 +671,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Return to the app and tap Ready button",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Rule chain"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Rule node"),
@@ -664,9 +679,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("Scan QR code"),
     "search": MessageLookupByLibrary.simpleMessage("Search"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Search results"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("seconds"),
     "security": MessageLookupByLibrary.simpleMessage("Security"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Select all loaded"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Select country"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Select region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Select users"),
@@ -690,7 +706,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severity"),
     "signIn": MessageLookupByLibrary.simpleMessage("Sign In"),
     "signUp": MessageLookupByLibrary.simpleMessage("Sign up"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "The next time you log in, you will be prompted to enter the security code that will be sent to the phone number",
@@ -753,7 +769,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Unable connect to device",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Unable to use camera",
     ),
@@ -765,7 +781,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("Unsaved changes"),
     "update": MessageLookupByLibrary.simpleMessage("Update"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update required"),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("User"),
     "username": MessageLookupByLibrary.simpleMessage("username"),
@@ -790,9 +806,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Warning"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widget type"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgets bundle"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi password"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Yes"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Yes, deactivate"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Yes, discard"),

--- a/lib/generated/intl/messages_es_ES.dart
+++ b/lib/generated/intl/messages_es_ES.dart
@@ -46,50 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Tablero', other: 'Tableros')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivos')}";
+      "${Intl.plural(count, one: '¿Eliminar 1 notificación?', other: '¿Eliminar ${count} notificaciones?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivos')}";
+
+  static String m11(count) =>
       "Código de ${count} ${Intl.plural(count, one: 'dígito', other: 'dígitos')}";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Se ha enviado un código de seguridad a tu correo electrónico en ${contact}.";
 
-  static String m12(e) => "Error ocurrido: ${e}";
+  static String m13(e) => "Error ocurrido: ${e}";
 
-  static String m13(error) => "Error al enviar el código: ${error}";
+  static String m14(error) => "Error al enviar el código: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 operación falló', other: '${count} operaciones fallaron')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: '¿Marcar 1 notificación como leída?', other: '¿Marcar ${count} notificaciones como leídas?')}";
+
+  static String m17(count) => "${count} seleccionados";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notificación', other: 'Notificaciones')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Abre la configuración de la app, otorga los permisos y toca \"Intentar de nuevo\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "No tienes suficientes permisos para \"${permissions}\" para continuar. Otorga los permisos necesarios y toca \"Intentar de nuevo\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Ingresa el PIN de ${deviceName} para confirmar la prueba de posesión";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Reenviar código en ${Intl.plural(time, one: '1 segundo', other: '${time} segundos')}";
 
-  static String m19(name) => "Ruta no definida: ${name}";
+  static String m23(name) => "Ruta no definida: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Buscar usuario', other: 'Buscar usuarios')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "Se ha enviado un código de seguridad a tu teléfono en ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "No se puede conectar al Wi-Fi porque el dispositivo ${name} no encontró redes";
 
-  static String m23(version) => "Actualizar a ${version}";
+  static String m27(version) => "Actualizar a ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "Para continuar con la configuración de tu dispositivo ${deviceName}, proporciona las credenciales de tu red.";
 
-  static String m25(network) => "Ingresa la contraseña de ${network}";
+  static String m29(network) => "Ingresa la contraseña de ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -367,6 +378,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "deleteComment": MessageLookupByLibrary.simpleMessage(
       "Eliminar comentario",
     ),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Detalles"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Lista de dispositivos"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -381,8 +393,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Aprovisionamiento de dispositivo",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Descartar cambios"),
     "domain": MessageLookupByLibrary.simpleMessage("Dominio"),
     "done": MessageLookupByLibrary.simpleMessage("Hecho"),
@@ -391,7 +403,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Editar"),
     "edited": MessageLookupByLibrary.simpleMessage("Editado"),
     "email": MessageLookupByLibrary.simpleMessage("Correo electrónico"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "Código de correo",
     ),
@@ -427,8 +439,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Tipo de entidad"),
     "entityView": MessageLookupByLibrary.simpleMessage("Vista de entidad"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -443,6 +455,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "No se pudo cargar la lista",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage(
       "Detalles del fallo",
     ),
@@ -510,6 +523,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Marcar todo como leído",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Marcar como leído"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Métrico"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Código de respaldo",
@@ -532,6 +546,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "¡El tablero móvil debe configurarse en el perfil del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Más"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nueva contraseña"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmar nueva contraseña",
@@ -578,12 +593,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Plantilla de notificación",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Cliente OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Abrir configuración de la app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Abre la configuración y concede acceso a la cámara para continuar",
@@ -618,7 +633,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Contraseña cambiada exitosamente",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permisos"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Teléfono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "El número de teléfono no es válido",
@@ -645,7 +660,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Escanea el código QR en tu dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo de alarma"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Código postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Política de privacidad",
@@ -676,7 +691,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reenviar"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reenviar código"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Restablecer"),
     "retry": MessageLookupByLibrary.simpleMessage("Reintentar"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -685,7 +700,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Vuelve a la aplicación y toca el botón Listo",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Cadena de reglas"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo de regla"),
@@ -695,9 +710,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Resultados de búsqueda",
     ),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("segundos"),
     "security": MessageLookupByLibrary.simpleMessage("Seguridad"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Seleccionar todo lo cargado",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Seleccionar país"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Seleccionar región"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Seleccionar usuarios"),
@@ -721,7 +739,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Severidad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Iniciar sesión"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrarse"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Código SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "La próxima vez que inicies sesión, se te pedirá que ingreses el código de seguridad enviado al número de teléfono",
@@ -787,7 +805,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "No se puede conectar al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "No se puede usar la cámara",
     ),
@@ -803,7 +821,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Actualización requerida",
     ),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Usuario"),
     "username": MessageLookupByLibrary.simpleMessage("nombre de usuario"),
@@ -828,9 +846,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advertencia"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Paquete de widgets"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Contraseña de Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Sí"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sí, desactivar"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sí, descartar"),

--- a/lib/generated/intl/messages_fr_FR.dart
+++ b/lib/generated/intl/messages_fr_FR.dart
@@ -47,50 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Tableau de bord', other: 'Tableaux de bord')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Appareil', other: 'Appareils')}";
+      "${Intl.plural(count, one: 'Supprimer 1 notification ?', other: 'Supprimer ${count} notifications ?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Appareil', other: 'Appareils')}";
+
+  static String m11(count) =>
       "Code à ${count} ${Intl.plural(count, one: 'chiffre', other: 'chiffres')}";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Un code de sécurité a été envoyé à votre adresse email à ${contact}.";
 
-  static String m12(e) => "Erreur survenue : ${e}";
+  static String m13(e) => "Erreur survenue : ${e}";
 
-  static String m13(error) => "Erreur lors de l\'envoi du code : ${error}";
+  static String m14(error) => "Erreur lors de l\'envoi du code : ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 opération a échoué', other: '${count} opérations ont échoué')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'Marquer 1 notification comme lue ?', other: 'Marquer ${count} notifications comme lues ?')}";
+
+  static String m17(count) => "${count} sélectionnés";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notification', other: 'Notifications')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez ouvrir les paramètres de l\'application, accorder les autorisations, puis appuyez sur \"Réessayer\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "Vous n\'avez pas les autorisations nécessaires pour \"${permissions}\". Veuillez accorder les autorisations requises et appuyez sur \"Réessayer\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Saisissez le code PIN de ${deviceName} pour confirmer la preuve de possession";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Renvoyer le code dans ${Intl.plural(time, one: '1 seconde', other: '${time} secondes')}";
 
-  static String m19(name) => "Route non définie : ${name}";
+  static String m23(name) => "Route non définie : ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Rechercher un utilisateur', other: 'Rechercher des utilisateurs')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "Un code de sécurité a été envoyé à votre téléphone au ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Impossible de se connecter au Wi-Fi car aucun réseau n\'a été trouvé par l\'appareil ${name}";
 
-  static String m23(version) => "Mettre à jour vers ${version}";
+  static String m27(version) => "Mettre à jour vers ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "Pour continuer la configuration de votre appareil ${deviceName}, veuillez fournir les identifiants de votre réseau.";
 
-  static String m25(network) => "Saisir le mot de passe pour ${network}";
+  static String m29(network) => "Saisir le mot de passe pour ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -370,6 +381,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "deleteComment": MessageLookupByLibrary.simpleMessage(
       "Supprimer le commentaire",
     ),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Détails"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Liste des appareils"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -384,8 +396,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Provisionnement de l\'appareil",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage(
       "Annuler les modifications",
     ),
@@ -396,7 +408,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Éditer"),
     "edited": MessageLookupByLibrary.simpleMessage("Édité"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Code email"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Format d\'email invalide.",
@@ -430,8 +442,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Type d\'entité"),
     "entityView": MessageLookupByLibrary.simpleMessage("Vue d\'entité"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europe"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Francfort"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -446,6 +458,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Échec du chargement de la liste",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage(
       "Détails de l\'échec",
     ),
@@ -517,6 +530,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Tout marquer comme lu",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Marquer comme lu"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Métrique"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Code de secours",
@@ -537,6 +551,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Le tableau de bord mobile doit être configuré dans le profil de l\'appareil !",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Plus"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nouveau mot de passe"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Confirmer le nouveau mot de passe",
@@ -583,12 +598,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modèle de notification",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Ouvrir les paramètres de l\'application",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Ouvrez les paramètres et accordez l\'accès à la caméra pour continuer",
@@ -623,7 +638,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Mot de passe changé avec succès",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Autorisations"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Téléphone"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Le numéro de téléphone est invalide",
@@ -650,7 +665,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Veuillez scanner le code QR sur votre appareil",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Type d\'alarme"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Code postal"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Politique de confidentialité",
@@ -683,7 +698,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Renvoyer"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Renvoyer le code"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Réinitialiser"),
     "retry": MessageLookupByLibrary.simpleMessage("Réessayer"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -692,7 +707,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Revenez à l\'application et appuyez sur le bouton Prêt",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chaîne de règles"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nœud de règle"),
@@ -702,9 +717,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Résultats de recherche",
     ),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("secondes"),
     "security": MessageLookupByLibrary.simpleMessage("Sécurité"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Sélectionner tout le chargé",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage(
       "Sélectionner le pays",
     ),
@@ -734,7 +752,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravité"),
     "signIn": MessageLookupByLibrary.simpleMessage("Se connecter"),
     "signUp": MessageLookupByLibrary.simpleMessage("S\'inscrire"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Code SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lors de votre prochaine connexion, vous devrez saisir le code de sécurité envoyé au numéro de téléphone",
@@ -804,7 +822,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossible de se connecter à l\'appareil",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossible d\'utiliser la caméra",
     ),
@@ -820,7 +838,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Mise à jour requise",
     ),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utilisateur"),
     "username": MessageLookupByLibrary.simpleMessage("nom d\'utilisateur"),
@@ -847,9 +865,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avertissement"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Type de widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pack de widgets"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mot de passe Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Oui"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Oui, désactiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Oui, annuler"),

--- a/lib/generated/intl/messages_it_IT.dart
+++ b/lib/generated/intl/messages_it_IT.dart
@@ -46,50 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboard')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivi')}";
+      "${Intl.plural(count, one: 'Eliminare 1 notifica?', other: 'Eliminare ${count} notifiche?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Dispositivo', other: 'Dispositivi')}";
+
+  static String m11(count) =>
       "Codice a ${count} ${Intl.plural(count, one: 'cifra', other: 'cifre')}";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Un codice di sicurezza è stato inviato alla tua email all\'indirizzo ${contact}.";
 
-  static String m12(e) => "Errore verificatosi: ${e}";
+  static String m13(e) => "Errore verificatosi: ${e}";
 
-  static String m13(error) => "Errore nell\'invio del codice: ${error}";
+  static String m14(error) => "Errore nell\'invio del codice: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 operazione non riuscita', other: '${count} operazioni non riuscite')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'Segnare 1 notifica come letta?', other: 'Segnare ${count} notifiche come lette?')}";
+
+  static String m17(count) => "${count} selezionati";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Notifica', other: 'Notifiche')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Apri le impostazioni dell\'app, concedi i permessi e tocca \"Riprova\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "Non hai i permessi necessari per \"${permissions}\" per procedere. Concedi i permessi richiesti e tocca \"Riprova\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Inserisci il PIN di ${deviceName} per confermare la prova di possesso";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Reinvia codice tra ${Intl.plural(time, one: '1 secondo', other: '${time} secondi')}";
 
-  static String m19(name) => "Percorso non definito: ${name}";
+  static String m23(name) => "Percorso non definito: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Cerca utente', other: 'Cerca utenti')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "Un codice di sicurezza è stato inviato al tuo telefono al numero ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Impossibile connettersi al Wi-Fi perché il dispositivo ${name} non ha trovato reti";
 
-  static String m23(version) => "Aggiorna a ${version}";
+  static String m27(version) => "Aggiorna a ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "Per continuare la configurazione del dispositivo ${deviceName}, fornisci le credenziali della tua rete.";
 
-  static String m25(network) => "Inserisci la password per ${network}";
+  static String m29(network) => "Inserisci la password per ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -353,6 +364,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Elimina"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Elimina account"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Elimina commento"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Dettagli"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Elenco dispositivi"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -367,8 +379,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Provisioning del dispositivo",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Annulla modifiche"),
     "domain": MessageLookupByLibrary.simpleMessage("Dominio"),
     "done": MessageLookupByLibrary.simpleMessage("Fatto"),
@@ -377,7 +389,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Modifica"),
     "edited": MessageLookupByLibrary.simpleMessage("Modificato"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage(
       "Codice email",
     ),
@@ -411,8 +423,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Tipo di entità"),
     "entityView": MessageLookupByLibrary.simpleMessage("Vista entità"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Francoforte"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -427,6 +439,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Impossibile caricare l\'elenco",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage(
       "Dettagli dell\'errore",
     ),
@@ -494,6 +507,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Segna tutto come letto",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Segna come letto"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrico"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Codice di backup",
@@ -514,6 +528,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "La dashboard mobile deve essere configurata nel profilo del dispositivo!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Altro"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nuova password"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Conferma nuova password",
@@ -560,12 +575,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Modello di notifica",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Client OAuth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Apri impostazioni app",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Apri le impostazioni e concedi l\'accesso alla fotocamera per continuare",
@@ -598,7 +613,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Password cambiata con successo",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Permessi"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefono"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Il numero di telefono non è valido",
@@ -625,7 +640,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scansiona il codice QR sul tuo dispositivo",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Tipo di allarme"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("CAP / Codice postale"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Informativa sulla privacy",
@@ -656,7 +671,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Reinvia"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Reinvia codice"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Reimposta"),
     "retry": MessageLookupByLibrary.simpleMessage("Riprova"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -665,7 +680,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Torna all\'app e tocca il pulsante Pronto",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Catena di regole"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nodo di regole"),
@@ -675,9 +690,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "searchResults": MessageLookupByLibrary.simpleMessage(
       "Risultati della ricerca",
     ),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("secondi"),
     "security": MessageLookupByLibrary.simpleMessage("Sicurezza"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Seleziona tutti i caricati",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Seleziona paese"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Seleziona regione"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Seleziona utenti"),
@@ -701,7 +719,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Gravità"),
     "signIn": MessageLookupByLibrary.simpleMessage("Accedi"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrati"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Codice SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Al prossimo accesso ti verrà chiesto di inserire il codice di sicurezza inviato al numero di telefono",
@@ -769,7 +787,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Impossibile connettersi al dispositivo",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Impossibile usare la fotocamera",
     ),
@@ -785,7 +803,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Aggiornamento richiesto",
     ),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Utente"),
     "username": MessageLookupByLibrary.simpleMessage("nome utente"),
@@ -812,9 +830,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Avviso"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Tipo di widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Pacchetto widget"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Password Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Sì"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Sì, disattiva"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Sì, annulla"),

--- a/lib/generated/intl/messages_nl_NL.dart
+++ b/lib/generated/intl/messages_nl_NL.dart
@@ -47,50 +47,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashboard', other: 'Dashboards')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Apparaat', other: 'Apparaten')}";
+      "${Intl.plural(count, one: '1 melding verwijderen?', other: '${count} meldingen verwijderen?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Apparaat', other: 'Apparaten')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'cijferige', other: 'cijferige')} code";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Er is een beveiligingscode verzonden naar uw e-mailadres op ${contact}.";
 
-  static String m12(e) => "Fout opgetreden: ${e}";
+  static String m13(e) => "Fout opgetreden: ${e}";
 
-  static String m13(error) => "Fout bij het verzenden van de code: ${error}";
+  static String m14(error) => "Fout bij het verzenden van de code: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 bewerking mislukt', other: '${count} bewerkingen mislukt')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: '1 melding als gelezen markeren?', other: '${count} meldingen als gelezen markeren?')}";
+
+  static String m17(count) => "${count} geselecteerd";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Melding', other: 'Meldingen')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Open de app-instellingen, verleen de rechten en tik op \"Opnieuw proberen\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "U heeft onvoldoende rechten voor \"${permissions}\" om door te gaan. Verleen de vereiste rechten en tik op \"Opnieuw proberen\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Voer de pincode van ${deviceName} in om eigendomsbewijs te bevestigen";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Code opnieuw verzenden in ${Intl.plural(time, one: '1 seconde', other: '${time} seconden')}";
 
-  static String m19(name) => "Route niet gedefinieerd: ${name}";
+  static String m23(name) => "Route niet gedefinieerd: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Gebruiker zoeken', other: 'Gebruikers zoeken')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "Er is een beveiligingscode verzonden naar uw telefoon op ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Kan niet verbinden met Wi-Fi omdat het apparaat ${name} geen netwerken heeft gevonden";
 
-  static String m23(version) => "Updaten naar ${version}";
+  static String m27(version) => "Updaten naar ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "Om de installatie van uw apparaat ${deviceName} voort te zetten, geef de netwerkgegevens op.";
 
-  static String m25(network) => "Voer het wachtwoord in voor ${network}";
+  static String m29(network) => "Voer het wachtwoord in voor ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -358,6 +369,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "deleteComment": MessageLookupByLibrary.simpleMessage(
       "Opmerking verwijderen",
     ),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Details"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Apparatenlijst"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -370,8 +382,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Apparaatprovisioning",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage(
       "Wijzigingen verwerpen",
     ),
@@ -382,7 +394,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Bewerken"),
     "edited": MessageLookupByLibrary.simpleMessage("Bewerkt"),
     "email": MessageLookupByLibrary.simpleMessage("E-mail"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("E-mailcode"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ongeldig e-mailformaat.",
@@ -418,8 +430,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Entiteitstype"),
     "entityView": MessageLookupByLibrary.simpleMessage("Entiteitsweergave"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -434,6 +446,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Laden van de lijst mislukt",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("Foutdetails"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "Fatale applicatiefout opgetreden:",
@@ -497,6 +510,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Alles als gelezen markeren",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Markeer als gelezen"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisch"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Back-upcode",
@@ -517,6 +531,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Het mobiele dashboard moet worden geconfigureerd in het apparaatprofiel!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Meer"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nieuw wachtwoord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bevestig nieuw wachtwoord",
@@ -561,12 +576,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Meldingssjabloon",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-client"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "App-instellingen openen",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Open instellingen en geef cameratoegang om door te gaan",
@@ -601,7 +616,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Wachtwoord succesvol gewijzigd",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Rechten"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefoon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefoonnummer is ongeldig",
@@ -628,7 +643,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Scan de QR-code op uw apparaat",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postcode"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("Privacybeleid"),
     "profile": MessageLookupByLibrary.simpleMessage("Profiel"),
@@ -659,7 +674,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "resendCode": MessageLookupByLibrary.simpleMessage(
       "Code opnieuw verzenden",
     ),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Herstellen"),
     "retry": MessageLookupByLibrary.simpleMessage("Opnieuw proberen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -668,7 +683,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Ga terug naar de app en tik op de knop Gereed",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelketen"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelknooppunt"),
@@ -676,9 +691,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("QR-code scannen"),
     "search": MessageLookupByLibrary.simpleMessage("Zoeken"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Zoekresultaten"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("seconden"),
     "security": MessageLookupByLibrary.simpleMessage("Beveiliging"),
+    "selectAll": MessageLookupByLibrary.simpleMessage(
+      "Alle geladen selecteren",
+    ),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Land selecteren"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Selecteer regio"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Gebruikers selecteren"),
@@ -702,7 +720,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Ernst"),
     "signIn": MessageLookupByLibrary.simpleMessage("Inloggen"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registreren"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-code"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "De volgende keer dat u inlogt, wordt u gevraagd de beveiligingscode in te voeren die naar uw telefoonnummer wordt gestuurd",
@@ -768,7 +786,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan niet verbinden met apparaat",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan camera niet gebruiken",
     ),
@@ -782,7 +800,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Bijwerken"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Update vereist"),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Gebruiker"),
     "username": MessageLookupByLibrary.simpleMessage("gebruikersnaam"),
@@ -807,9 +825,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Waarschuwing"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakket"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-wachtwoord"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deactiveren"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, verwerpen"),

--- a/lib/generated/intl/messages_no_NO.dart
+++ b/lib/generated/intl/messages_no_NO.dart
@@ -46,50 +46,61 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Dashbord', other: 'Dashbord')}";
 
   static String m9(count) =>
-      "${Intl.plural(count, one: 'Enhet', other: 'Enheter')}";
+      "${Intl.plural(count, one: 'Slette 1 varsling?', other: 'Slette ${count} varslinger?')}";
 
   static String m10(count) =>
+      "${Intl.plural(count, one: 'Enhet', other: 'Enheter')}";
+
+  static String m11(count) =>
       "${count}-${Intl.plural(count, one: 'sifret', other: 'sifret')} kode";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "En sikkerhetskode har blitt sendt til e-postadressen din på ${contact}.";
 
-  static String m12(e) => "Feil oppstod: ${e}";
+  static String m13(e) => "Feil oppstod: ${e}";
 
-  static String m13(error) => "Feil ved sending av kode: ${error}";
+  static String m14(error) => "Feil ved sending av kode: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 handling mislyktes', other: '${count} handlinger mislyktes')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'Markere 1 varsling som lest?', other: 'Markere ${count} varslinger som lest?')}";
+
+  static String m17(count) => "${count} valgt";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Varsel', other: 'Varsler')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Åpne appinnstillingene, gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "Du har ikke tilstrekkelige tillatelser for \"${permissions}\" til å fortsette. Gi nødvendige tillatelser og trykk \"Prøv igjen\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Skriv inn PIN for ${deviceName} for å bekrefte eierskapsbevis";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Send koden på nytt om ${Intl.plural(time, one: '1 sekund', other: '${time} sekunder')}";
 
-  static String m19(name) => "Rute ikke definert: ${name}";
+  static String m23(name) => "Rute ikke definert: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Søk bruker', other: 'Søk brukere')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "En sikkerhetskode har blitt sendt til telefonen din på ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Kan ikke koble til Wi-Fi fordi enheten ${name} ikke fant nettverk";
 
-  static String m23(version) => "Oppdater til ${version}";
+  static String m27(version) => "Oppdater til ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "For å fortsette oppsettet av enheten din ${deviceName}, vennligst oppgi nettverksinformasjonen din.";
 
-  static String m25(network) => "Skriv inn passordet for ${network}";
+  static String m29(network) => "Skriv inn passordet for ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -347,6 +358,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Slett"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Slett konto"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Slett kommentar"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Detaljer"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Enhetsliste"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -359,8 +371,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Enhetsklargjøring",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Forkast endringer"),
     "domain": MessageLookupByLibrary.simpleMessage("Domene"),
     "done": MessageLookupByLibrary.simpleMessage("Ferdig"),
@@ -369,7 +381,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Rediger"),
     "edited": MessageLookupByLibrary.simpleMessage("Redigert"),
     "email": MessageLookupByLibrary.simpleMessage("E-post"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("E-postkode"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Ugyldig e-postformat.",
@@ -403,8 +415,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Enhetstype"),
     "entityView": MessageLookupByLibrary.simpleMessage("Enhetsvisning"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Europa"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -419,6 +431,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Kunne ikke laste listen",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("Feildetaljer"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "Fatal applikasjonsfeil oppstod:",
@@ -480,6 +493,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("Alvorlig"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("Merk alle som lest"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Merk som lest"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Metrisk"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Reservekode",
@@ -498,6 +512,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Mobilt dashbord må konfigureres i enhetsprofilen!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Mer"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Nytt passord"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Bekreft nytt passord",
@@ -542,12 +557,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Varslingsmal",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2-klient"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Åpne appinnstillinger",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Åpne innstillinger og gi tilgang til kameraet for å fortsette",
@@ -582,7 +597,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Passordet ble endret",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Tillatelser"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Telefon"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Telefonnummer er ugyldig",
@@ -609,7 +624,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Skann QR-koden på enheten din",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Alarmtype"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Postnummer"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Personvernerklæring",
@@ -640,7 +655,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Send på nytt"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Send koden på nytt"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Tilbakestill"),
     "retry": MessageLookupByLibrary.simpleMessage("Prøv igjen"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -649,7 +664,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Gå tilbake til appen og trykk Klar-knappen",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Regelkjede"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Regelnode"),
@@ -657,9 +672,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("Skann QR-kode"),
     "search": MessageLookupByLibrary.simpleMessage("Søk"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Søkeresultater"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("sekunder"),
     "security": MessageLookupByLibrary.simpleMessage("Sikkerhet"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Velg alle lastede"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Velg land"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Velg region"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Velg brukere"),
@@ -683,7 +699,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Alvorlighetsgrad"),
     "signIn": MessageLookupByLibrary.simpleMessage("Logg inn"),
     "signUp": MessageLookupByLibrary.simpleMessage("Registrer deg"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("SMS-kode"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Neste gang du logger inn, vil du bli bedt om å taste inn sikkerhetskoden som sendes til telefonnummeret",
@@ -741,7 +757,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Kan ikke koble til enhet",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Kan ikke bruke kameraet",
     ),
@@ -757,7 +773,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "updateRequired": MessageLookupByLibrary.simpleMessage(
       "Oppdatering kreves",
     ),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("URL"),
     "user": MessageLookupByLibrary.simpleMessage("Bruker"),
     "username": MessageLookupByLibrary.simpleMessage("brukernavn"),
@@ -782,9 +798,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Advarsel"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Widgettype"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Widgetpakke"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi-passord"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Ja"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Ja, deaktiver"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Ja, forkast"),

--- a/lib/generated/intl/messages_vi_VN.dart
+++ b/lib/generated/intl/messages_vi_VN.dart
@@ -46,49 +46,60 @@ class MessageLookup extends MessageLookupByLibrary {
       "${Intl.plural(count, one: 'Bảng điều khiển', other: 'Bảng điều khiển')}";
 
   static String m9(count) =>
+      "${Intl.plural(count, one: 'Xóa 1 thông báo?', other: 'Xóa ${count} thông báo?')}";
+
+  static String m10(count) =>
       "${Intl.plural(count, one: 'Thiết bị', other: 'Thiết bị')}";
 
-  static String m10(count) => "Mã ${count} chữ số";
+  static String m11(count) => "Mã ${count} chữ số";
 
-  static String m11(contact) =>
+  static String m12(contact) =>
       "Mã bảo mật đã được gửi đến địa chỉ email của bạn tại ${contact}.";
 
-  static String m12(e) => "Đã xảy ra lỗi: ${e}";
+  static String m13(e) => "Đã xảy ra lỗi: ${e}";
 
-  static String m13(error) => "Lỗi khi gửi mã: ${error}";
+  static String m14(error) => "Lỗi khi gửi mã: ${error}";
 
-  static String m14(count) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 thao tác thất bại', other: '${count} thao tác thất bại')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: 'Đánh dấu 1 thông báo đã đọc?', other: 'Đánh dấu ${count} thông báo đã đọc?')}";
+
+  static String m17(count) => "${count} đã chọn";
+
+  static String m18(count) =>
       "${Intl.plural(count, one: 'Thông báo', other: 'Thông báo')}";
 
-  static String m15(permissions) =>
+  static String m19(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng mở cài đặt ứng dụng, cấp quyền và nhấn \"Thử lại\".";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "Bạn không có đủ quyền cho \"${permissions}\" để tiếp tục. Vui lòng cấp các quyền cần thiết và nhấn \"Thử lại\".";
 
-  static String m17(deviceName) =>
+  static String m21(deviceName) =>
       "Nhập mã PIN của ${deviceName} để xác nhận bằng chứng sở hữu";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "Gửi lại mã sau ${Intl.plural(time, other: '${time} giây')}";
 
-  static String m19(name) => "Lộ trình chưa được xác định: ${name}";
+  static String m23(name) => "Lộ trình chưa được xác định: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: 'Tìm kiếm người dùng', other: 'Tìm kiếm người dùng')}";
 
-  static String m21(contact) =>
+  static String m25(contact) =>
       "Mã bảo mật đã được gửi đến điện thoại của bạn tại ${contact}.";
 
-  static String m22(name) =>
+  static String m26(name) =>
       "Không thể kết nối với Wi-Fi vì thiết bị ${name} không tìm thấy mạng";
 
-  static String m23(version) => "Cập nhật lên ${version}";
+  static String m27(version) => "Cập nhật lên ${version}";
 
-  static String m24(deviceName) =>
+  static String m28(deviceName) =>
       "Để tiếp tục thiết lập thiết bị ${deviceName} của bạn, vui lòng cung cấp thông tin đăng nhập Mạng của bạn.";
 
-  static String m25(network) => "Nhập mật khẩu cho ${network}";
+  static String m29(network) => "Nhập mật khẩu cho ${network}";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -354,6 +365,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("Xóa"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("Xóa tài khoản"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("Xóa bình luận"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("Chi tiết"),
     "deviceList": MessageLookupByLibrary.simpleMessage("Danh sách thiết bị"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -366,8 +378,8 @@ class MessageLookup extends MessageLookupByLibrary {
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage(
       "Cung cấp thiết bị",
     ),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("Hủy thay đổi"),
     "domain": MessageLookupByLibrary.simpleMessage("Tên miền"),
     "done": MessageLookupByLibrary.simpleMessage("Hoàn tất"),
@@ -376,7 +388,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("Chỉnh sửa"),
     "edited": MessageLookupByLibrary.simpleMessage("Đã chỉnh sửa"),
     "email": MessageLookupByLibrary.simpleMessage("Email"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Mã email"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage(
       "Định dạng email không hợp lệ.",
@@ -410,8 +422,8 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "entityType": MessageLookupByLibrary.simpleMessage("Loại thực thể"),
     "entityView": MessageLookupByLibrary.simpleMessage("Chế độ xem thực thể"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("Châu Âu"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("Frankfurt"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage(
@@ -426,6 +438,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage(
       "Không thể tải danh sách",
     ),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("Chi tiết lỗi"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "Đã xảy ra lỗi ứng dụng nghiêm trọng:",
@@ -497,6 +510,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Đánh dấu tất cả là đã đọc",
     ),
     "markAsRead": MessageLookupByLibrary.simpleMessage("Đánh dấu là đã đọc"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("Hệ mét"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage(
       "Mã dự phòng",
@@ -517,6 +531,7 @@ class MessageLookup extends MessageLookupByLibrary {
           "Bảng điều khiển di động phải được cấu hình trong hồ sơ thiết bị!",
         ),
     "more": MessageLookupByLibrary.simpleMessage("Thêm"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu mới"),
     "newPassword2": MessageLookupByLibrary.simpleMessage(
       "Xác nhận mật khẩu mới",
@@ -565,12 +580,12 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationTemplate": MessageLookupByLibrary.simpleMessage(
       "Mẫu thông báo",
     ),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("Máy khách Oauth2"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage(
       "Mở cài đặt ứng dụng",
     ),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage(
           "Mở cài đặt và cấp quyền truy cập camera để tiếp tục",
@@ -603,7 +618,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Đổi mật khẩu thành công",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("Quyền"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("Điện thoại"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage(
       "Số điện thoại không hợp lệ",
@@ -630,7 +645,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "Vui lòng quét mã QR trên thiết bị của bạn",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ Loại cảnh báo"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("Mã Zip / Mã bưu điện"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage(
       "Chính sách quyền riêng tư",
@@ -663,7 +678,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("Gửi lại"),
     "resendCode": MessageLookupByLibrary.simpleMessage("Gửi lại mã"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("Đặt lại"),
     "retry": MessageLookupByLibrary.simpleMessage("Thử lại"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage(
@@ -672,7 +687,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "Quay lại ứng dụng và nhấn nút Sẵn sàng",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("Chuỗi quy tắc"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("Nút quy tắc"),
@@ -680,9 +695,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("Quét mã QR"),
     "search": MessageLookupByLibrary.simpleMessage("Tìm kiếm"),
     "searchResults": MessageLookupByLibrary.simpleMessage("Kết quả tìm kiếm"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("giây"),
     "security": MessageLookupByLibrary.simpleMessage("Bảo mật"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("Chọn tất cả đã tải"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("Chọn quốc gia"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("Chọn khu vực"),
     "selectUser": MessageLookupByLibrary.simpleMessage("Chọn người dùng"),
@@ -706,7 +722,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("Mức độ nghiêm trọng"),
     "signIn": MessageLookupByLibrary.simpleMessage("Đăng nhập"),
     "signUp": MessageLookupByLibrary.simpleMessage("Đăng ký"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("Mã SMS"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "Lần tiếp theo bạn đăng nhập, bạn sẽ được yêu cầu nhập mã bảo mật được gửi đến số điện thoại",
@@ -766,7 +782,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage(
       "Không thể kết nối với thiết bị",
     ),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage(
       "Không thể sử dụng camera",
     ),
@@ -780,7 +796,7 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "update": MessageLookupByLibrary.simpleMessage("Cập nhật"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("Yêu cầu cập nhật"),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("Url"),
     "user": MessageLookupByLibrary.simpleMessage("Người dùng"),
     "username": MessageLookupByLibrary.simpleMessage("tên người dùng"),
@@ -807,9 +823,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("Cảnh báo"),
     "widgetType": MessageLookupByLibrary.simpleMessage("Loại widget"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("Gói widget"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Mật khẩu Wi-Fi"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("Có"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("Có, hủy kích hoạt"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("Có, hủy"),

--- a/lib/generated/intl/messages_zh_CN.dart
+++ b/lib/generated/intl/messages_zh_CN.dart
@@ -40,43 +40,54 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(count) => "${Intl.plural(count, one: '仪表板', other: '仪表板')}";
 
-  static String m9(count) => "${Intl.plural(count, one: '设备', other: '设备')}";
+  static String m9(count) =>
+      "${Intl.plural(count, one: '删除 1 条通知？', other: '删除 ${count} 条通知？')}";
 
-  static String m10(count) => "${count}位数验证码";
+  static String m10(count) => "${Intl.plural(count, one: '设备', other: '设备')}";
 
-  static String m11(contact) => "安全码已发送到您的邮箱 ${contact}。";
+  static String m11(count) => "${count}位数验证码";
 
-  static String m12(e) => "发生错误：${e}";
+  static String m12(contact) => "安全码已发送到您的邮箱 ${contact}。";
 
-  static String m13(error) => "发送验证码错误：${error}";
+  static String m13(e) => "发生错误：${e}";
 
-  static String m14(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m14(error) => "发送验证码错误：${error}";
 
-  static String m15(permissions) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 项操作失败', other: '${count} 项操作失败')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: '将 1 条通知标记为已读？', other: '将 ${count} 条通知标记为已读？')}";
+
+  static String m17(count) => "已选择 ${count} 项";
+
+  static String m18(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+
+  static String m19(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请打开应用设置，授予权限并点击\"再试一次\"。";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "您没有足够的\"${permissions}\"权限以继续。请授予所需权限并点击\"再试一次\"。";
 
-  static String m17(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
+  static String m21(deviceName) => "输入 ${deviceName} 的PIN码以确认拥有权证明";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}内重新发送验证码";
 
-  static String m19(name) => "路由未定义: ${name}";
+  static String m23(name) => "路由未定义: ${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: '搜索用户', other: '搜索用户')}";
 
-  static String m21(contact) => "安全码已发送到您的手机 ${contact}。";
+  static String m25(contact) => "安全码已发送到您的手机 ${contact}。";
 
-  static String m22(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
+  static String m26(name) => "无法连接 Wi-Fi，因为设备 ${name} 未找到网络";
 
-  static String m23(version) => "更新到 ${version}";
+  static String m27(version) => "更新到 ${version}";
 
-  static String m24(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
+  static String m28(deviceName) => "要继续设置您的设备 ${deviceName}，请提供您网络的凭据。";
 
-  static String m25(network) => "输入 ${network} 的密码";
+  static String m29(network) => "输入 ${network} 的密码";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -264,6 +275,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("删除"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("删除账户"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("删除评论"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("详情"),
     "deviceList": MessageLookupByLibrary.simpleMessage("设备列表"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -274,8 +286,8 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "deviceProfile": MessageLookupByLibrary.simpleMessage("设备配置文件"),
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage("设备配置"),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("放弃更改"),
     "domain": MessageLookupByLibrary.simpleMessage("域名"),
     "done": MessageLookupByLibrary.simpleMessage("完成"),
@@ -284,7 +296,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("编辑"),
     "edited": MessageLookupByLibrary.simpleMessage("已编辑"),
     "email": MessageLookupByLibrary.simpleMessage("邮箱"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("邮箱验证码"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage("邮箱格式无效"),
     "emailRequireText": MessageLookupByLibrary.simpleMessage("邮箱是必填项"),
@@ -308,8 +320,8 @@ class MessageLookup extends MessageLookupByLibrary {
         MessageLookupByLibrary.simpleMessage("输入用于验证的电子邮箱。"),
     "entityType": MessageLookupByLibrary.simpleMessage("实体类型"),
     "entityView": MessageLookupByLibrary.simpleMessage("实体视图"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("欧洲"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("法兰克福"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage("退出设备配置"),
@@ -318,6 +330,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "加载告警详情失败",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("加载列表失败"),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("失败详情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "发生致命应用程序错误：",
@@ -371,6 +384,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("重要"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("全部标记为已读"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("标记为已读"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("公制"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage("备份码"),
     "mfaProviderEmail": MessageLookupByLibrary.simpleMessage("邮箱"),
@@ -383,6 +397,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在设备配置文件中配置移动仪表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密码"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("确认新密码"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("请再次输入新密码"),
@@ -403,10 +418,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知规则"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目标"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知模板"),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 客户端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("打开应用设置"),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("打开设置并授予摄像头访问权限以继续"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("打开 Wi-Fi 设置"),
@@ -429,7 +444,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密码修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("权限"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("电话"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手机号码无效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手机号码是必填项"),
@@ -446,7 +461,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "请扫描您设备上的二维码",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 告警类型"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("邮编"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隐私政策"),
     "profile": MessageLookupByLibrary.simpleMessage("个人资料"),
@@ -467,14 +482,14 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新发送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新发送验证码"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("重置"),
     "retry": MessageLookupByLibrary.simpleMessage("重试"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回仪表板"),
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "返回应用并点击准备好按钮",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("规则链"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("规则节点"),
@@ -482,9 +497,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("扫描二维码"),
     "search": MessageLookupByLibrary.simpleMessage("搜索"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜索结果"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全选已加载"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("选择国家"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("选择地区"),
     "selectUser": MessageLookupByLibrary.simpleMessage("选择用户"),
@@ -500,7 +516,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("严重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登录"),
     "signUp": MessageLookupByLibrary.simpleMessage("注册"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("短信验证码"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登录时，您将需要输入发送到手机号码的安全码",
@@ -546,7 +562,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("类型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("无法连接到设备"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("无法使用摄像头"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未确认"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未分配"),
@@ -556,7 +572,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未保存的更改"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("链接"),
     "user": MessageLookupByLibrary.simpleMessage("用户"),
     "username": MessageLookupByLibrary.simpleMessage("用户名"),
@@ -573,9 +589,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("组件类型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("组件包"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密码"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，放弃"),

--- a/lib/generated/intl/messages_zh_TW.dart
+++ b/lib/generated/intl/messages_zh_TW.dart
@@ -40,43 +40,54 @@ class MessageLookup extends MessageLookupByLibrary {
 
   static String m8(count) => "${Intl.plural(count, one: '儀表板', other: '儀表板')}";
 
-  static String m9(count) => "${Intl.plural(count, one: '設備', other: '設備')}";
+  static String m9(count) =>
+      "${Intl.plural(count, one: '刪除 1 則通知？', other: '刪除 ${count} 則通知？')}";
 
-  static String m10(count) => "${count}位數驗證碼";
+  static String m10(count) => "${Intl.plural(count, one: '設備', other: '設備')}";
 
-  static String m11(contact) => "安全碼已發送到您的電子郵件 ${contact}。";
+  static String m11(count) => "${count}位數驗證碼";
 
-  static String m12(e) => "發生錯誤：${e}";
+  static String m12(contact) => "安全碼已發送到您的電子郵件 ${contact}。";
 
-  static String m13(error) => "傳送驗證碼錯誤：${error}";
+  static String m13(e) => "發生錯誤：${e}";
 
-  static String m14(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+  static String m14(error) => "傳送驗證碼錯誤：${error}";
 
-  static String m15(permissions) =>
+  static String m15(count) =>
+      "${Intl.plural(count, one: '1 項操作失敗', other: '${count} 項操作失敗')}";
+
+  static String m16(count) =>
+      "${Intl.plural(count, one: '將 1 則通知標記為已讀？', other: '將 ${count} 則通知標記為已讀？')}";
+
+  static String m17(count) => "已選擇 ${count} 項";
+
+  static String m18(count) => "${Intl.plural(count, one: '通知', other: '通知')}";
+
+  static String m19(permissions) =>
       "您沒有足夠的「${permissions}」權限以繼續。請開啟應用程式設定，授予權限並點選「再試一次」。";
 
-  static String m16(permissions) =>
+  static String m20(permissions) =>
       "您沒有足夠的「${permissions}」權限以繼續。請授予所需權限並點選「再試一次」。";
 
-  static String m17(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
+  static String m21(deviceName) => "輸入 ${deviceName} 的PIN碼以確認持有權證明";
 
-  static String m18(time) =>
+  static String m22(time) =>
       "在 ${Intl.plural(time, one: '1 秒', other: '${time} 秒')}內重新發送驗證碼";
 
-  static String m19(name) => "路由未定義：${name}";
+  static String m23(name) => "路由未定義：${name}";
 
-  static String m20(count) =>
+  static String m24(count) =>
       "${Intl.plural(count, one: '搜尋使用者', other: '搜尋使用者')}";
 
-  static String m21(contact) => "安全碼已發送到您的手機 ${contact}。";
+  static String m25(contact) => "安全碼已發送到您的手機 ${contact}。";
 
-  static String m22(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
+  static String m26(name) => "無法連線 Wi-Fi，因為設備 ${name} 未找到網路";
 
-  static String m23(version) => "更新至 ${version}";
+  static String m27(version) => "更新至 ${version}";
 
-  static String m24(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
+  static String m28(deviceName) => "要繼續設定您的設備 ${deviceName}，請提供您網路的認證資料。";
 
-  static String m25(network) => "輸入 ${network} 的密碼";
+  static String m29(network) => "輸入 ${network} 的密碼";
 
   final messages = _notInlinedMessages(_notInlinedMessages);
   static Map<String, Function> _notInlinedMessages(_) => <String, Function>{
@@ -266,6 +277,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "delete": MessageLookupByLibrary.simpleMessage("刪除"),
     "deleteAccount": MessageLookupByLibrary.simpleMessage("刪除帳戶"),
     "deleteComment": MessageLookupByLibrary.simpleMessage("刪除評論"),
+    "deleteSelectedNotifications": m9,
     "details": MessageLookupByLibrary.simpleMessage("詳情"),
     "deviceList": MessageLookupByLibrary.simpleMessage("設備清單"),
     "deviceNotAbleToFindWifiNearby": MessageLookupByLibrary.simpleMessage(
@@ -276,8 +288,8 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "deviceProfile": MessageLookupByLibrary.simpleMessage("設備設定檔"),
     "deviceProvisioning": MessageLookupByLibrary.simpleMessage("設備設定"),
-    "devices": m9,
-    "digitsCode": m10,
+    "devices": m10,
+    "digitsCode": m11,
     "discardChanges": MessageLookupByLibrary.simpleMessage("捨棄變更"),
     "domain": MessageLookupByLibrary.simpleMessage("網域"),
     "done": MessageLookupByLibrary.simpleMessage("完成"),
@@ -286,7 +298,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "edit": MessageLookupByLibrary.simpleMessage("編輯"),
     "edited": MessageLookupByLibrary.simpleMessage("已編輯"),
     "email": MessageLookupByLibrary.simpleMessage("電子郵件"),
-    "emailAuthDescription": m11,
+    "emailAuthDescription": m12,
     "emailAuthPlaceholder": MessageLookupByLibrary.simpleMessage("電子郵件驗證碼"),
     "emailInvalidText": MessageLookupByLibrary.simpleMessage("電子郵件格式無效"),
     "emailRequireText": MessageLookupByLibrary.simpleMessage("電子郵件為必填項目"),
@@ -310,8 +322,8 @@ class MessageLookup extends MessageLookupByLibrary {
         MessageLookupByLibrary.simpleMessage("輸入用於驗證的電子郵件。"),
     "entityType": MessageLookupByLibrary.simpleMessage("實體類型"),
     "entityView": MessageLookupByLibrary.simpleMessage("實體視圖"),
-    "errorOccured": m12,
-    "errorSendingCode": m13,
+    "errorOccured": m13,
+    "errorSendingCode": m14,
     "europe": MessageLookupByLibrary.simpleMessage("歐洲"),
     "europeRegionShort": MessageLookupByLibrary.simpleMessage("法蘭克福"),
     "exitDeviceProvisioning": MessageLookupByLibrary.simpleMessage("退出設備設定"),
@@ -320,6 +332,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "載入警報詳情失敗",
     ),
     "failedToLoadTheList": MessageLookupByLibrary.simpleMessage("載入清單失敗"),
+    "failedToPerformOperation": m15,
     "failureDetails": MessageLookupByLibrary.simpleMessage("失敗詳情"),
     "fatalApplicationErrorOccurred": MessageLookupByLibrary.simpleMessage(
       "發生致命應用程式錯誤：",
@@ -373,6 +386,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "major": MessageLookupByLibrary.simpleMessage("重要"),
     "markAllAsRead": MessageLookupByLibrary.simpleMessage("全部標記為已讀"),
     "markAsRead": MessageLookupByLibrary.simpleMessage("標記為已讀"),
+    "markSelectedNotificationsAsRead": m16,
     "metricUnitSystem": MessageLookupByLibrary.simpleMessage("公制"),
     "mfaProviderBackupCode": MessageLookupByLibrary.simpleMessage("備份碼"),
     "mfaProviderEmail": MessageLookupByLibrary.simpleMessage("電子郵件"),
@@ -385,6 +399,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "mobileDashboardShouldBeConfiguredInDeviceProfile":
         MessageLookupByLibrary.simpleMessage("需要在設備設定檔中設定行動儀表板！"),
     "more": MessageLookupByLibrary.simpleMessage("更多"),
+    "nSelected": m17,
     "newPassword": MessageLookupByLibrary.simpleMessage("新密碼"),
     "newPassword2": MessageLookupByLibrary.simpleMessage("確認新密碼"),
     "newPassword2RequireText": MessageLookupByLibrary.simpleMessage("請再次輸入新密碼"),
@@ -405,10 +420,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "notificationRule": MessageLookupByLibrary.simpleMessage("通知規則"),
     "notificationTarget": MessageLookupByLibrary.simpleMessage("通知目標"),
     "notificationTemplate": MessageLookupByLibrary.simpleMessage("通知範本"),
-    "notifications": m14,
+    "notifications": m18,
     "oauth2Client": MessageLookupByLibrary.simpleMessage("OAuth2 用戶端"),
     "openAppSettings": MessageLookupByLibrary.simpleMessage("開啟應用程式設定"),
-    "openAppSettingsToGrantPermissionMessage": m15,
+    "openAppSettingsToGrantPermissionMessage": m19,
     "openSettingsAndGrantAccessToCameraToContinue":
         MessageLookupByLibrary.simpleMessage("開啟設定並授予攝影機存取權限以繼續"),
     "openWifiSettings": MessageLookupByLibrary.simpleMessage("開啟 Wi-Fi 設定"),
@@ -431,7 +446,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "密碼修改成功",
     ),
     "permissions": MessageLookupByLibrary.simpleMessage("權限"),
-    "permissionsNotEnoughMessage": m16,
+    "permissionsNotEnoughMessage": m20,
     "phone": MessageLookupByLibrary.simpleMessage("電話"),
     "phoneIsInvalid": MessageLookupByLibrary.simpleMessage("手機號碼無效"),
     "phoneIsRequired": MessageLookupByLibrary.simpleMessage("手機號碼為必填項目"),
@@ -448,7 +463,7 @@ class MessageLookup extends MessageLookupByLibrary {
       "請掃描您設備上的 QR 碼",
     ),
     "plusAlarmType": MessageLookupByLibrary.simpleMessage("+ 警報類型"),
-    "popTitle": m17,
+    "popTitle": m21,
     "postalCode": MessageLookupByLibrary.simpleMessage("郵遞區號"),
     "privacyPolicy": MessageLookupByLibrary.simpleMessage("隱私權政策"),
     "profile": MessageLookupByLibrary.simpleMessage("個人資料"),
@@ -469,14 +484,14 @@ class MessageLookup extends MessageLookupByLibrary {
     ),
     "resend": MessageLookupByLibrary.simpleMessage("重新發送"),
     "resendCode": MessageLookupByLibrary.simpleMessage("重新發送驗證碼"),
-    "resendCodeWait": m18,
+    "resendCodeWait": m22,
     "reset": MessageLookupByLibrary.simpleMessage("重設"),
     "retry": MessageLookupByLibrary.simpleMessage("重試"),
     "returnToDashboard": MessageLookupByLibrary.simpleMessage("返回儀表板"),
     "returnToTheAppAndTapReadyButton": MessageLookupByLibrary.simpleMessage(
       "返回應用程式並點選準備好按鈕",
     ),
-    "routeNotDefined": m19,
+    "routeNotDefined": m23,
     "rpc": MessageLookupByLibrary.simpleMessage("RPC"),
     "ruleChain": MessageLookupByLibrary.simpleMessage("規則鏈"),
     "ruleNode": MessageLookupByLibrary.simpleMessage("規則節點"),
@@ -484,9 +499,10 @@ class MessageLookup extends MessageLookupByLibrary {
     "scanQrCode": MessageLookupByLibrary.simpleMessage("掃描QR碼"),
     "search": MessageLookupByLibrary.simpleMessage("搜尋"),
     "searchResults": MessageLookupByLibrary.simpleMessage("搜尋結果"),
-    "searchUsers": m20,
+    "searchUsers": m24,
     "seconds": MessageLookupByLibrary.simpleMessage("秒"),
     "security": MessageLookupByLibrary.simpleMessage("安全性"),
+    "selectAll": MessageLookupByLibrary.simpleMessage("全選已載入"),
     "selectCountry": MessageLookupByLibrary.simpleMessage("選擇國家"),
     "selectRegion": MessageLookupByLibrary.simpleMessage("選擇地區"),
     "selectUser": MessageLookupByLibrary.simpleMessage("選擇使用者"),
@@ -502,7 +518,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "severity": MessageLookupByLibrary.simpleMessage("嚴重程度"),
     "signIn": MessageLookupByLibrary.simpleMessage("登入"),
     "signUp": MessageLookupByLibrary.simpleMessage("註冊"),
-    "smsAuthDescription": m21,
+    "smsAuthDescription": m25,
     "smsAuthPlaceholder": MessageLookupByLibrary.simpleMessage("簡訊驗證碼"),
     "smsSetupSuccessDescription": MessageLookupByLibrary.simpleMessage(
       "下次登入時，您將需要輸入傳送到手機號碼的安全碼",
@@ -548,7 +564,7 @@ class MessageLookup extends MessageLookupByLibrary {
         ),
     "type": MessageLookupByLibrary.simpleMessage("類型"),
     "unableConnectToDevice": MessageLookupByLibrary.simpleMessage("無法連線到設備"),
-    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m22,
+    "unableConnectToWifiBecauseNetworksWasntFoundByDevice": m26,
     "unableToUseCamera": MessageLookupByLibrary.simpleMessage("無法使用攝影機"),
     "unacknowledged": MessageLookupByLibrary.simpleMessage("未確認"),
     "unassigned": MessageLookupByLibrary.simpleMessage("未指派"),
@@ -558,7 +574,7 @@ class MessageLookup extends MessageLookupByLibrary {
     "unsavedChanges": MessageLookupByLibrary.simpleMessage("未儲存的變更"),
     "update": MessageLookupByLibrary.simpleMessage("更新"),
     "updateRequired": MessageLookupByLibrary.simpleMessage("需要更新"),
-    "updateTo": m23,
+    "updateTo": m27,
     "url": MessageLookupByLibrary.simpleMessage("連結"),
     "user": MessageLookupByLibrary.simpleMessage("使用者"),
     "username": MessageLookupByLibrary.simpleMessage("使用者名稱"),
@@ -575,9 +591,9 @@ class MessageLookup extends MessageLookupByLibrary {
     "warning": MessageLookupByLibrary.simpleMessage("警告"),
     "widgetType": MessageLookupByLibrary.simpleMessage("元件類型"),
     "widgetsBundle": MessageLookupByLibrary.simpleMessage("元件包"),
-    "wifiHelpMessage": m24,
+    "wifiHelpMessage": m28,
     "wifiPassword": MessageLookupByLibrary.simpleMessage("Wi-Fi 密碼"),
-    "wifiPasswordMessage": m25,
+    "wifiPasswordMessage": m29,
     "yes": MessageLookupByLibrary.simpleMessage("是"),
     "yesDeactivate": MessageLookupByLibrary.simpleMessage("是的，停用"),
     "yesDiscard": MessageLookupByLibrary.simpleMessage("是的，捨棄"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -3277,6 +3277,62 @@ class S {
       args: [],
     );
   }
+
+  /// `{count} selected`
+  String nSelected(int count) {
+    return Intl.message(
+      '$count selected',
+      name: 'nSelected',
+      desc: '',
+      args: [count],
+    );
+  }
+
+  /// `Select all loaded`
+  String get selectAll {
+    return Intl.message(
+      'Select all loaded',
+      name: 'selectAll',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `{count, plural, =1{1 operation failed} other{{count} operations failed}}`
+  String failedToPerformOperation(int count) {
+    return Intl.plural(
+      count,
+      one: '1 operation failed',
+      other: '$count operations failed',
+      name: 'failedToPerformOperation',
+      desc: '',
+      args: [count],
+    );
+  }
+
+  /// `{count, plural, =1{Delete 1 notification?} other{Delete {count} notifications?}}`
+  String deleteSelectedNotifications(int count) {
+    return Intl.plural(
+      count,
+      one: 'Delete 1 notification?',
+      other: 'Delete $count notifications?',
+      name: 'deleteSelectedNotifications',
+      desc: '',
+      args: [count],
+    );
+  }
+
+  /// `{count, plural, =1{Mark 1 notification as read?} other{Mark {count} notifications as read?}}`
+  String markSelectedNotificationsAsRead(int count) {
+    return Intl.plural(
+      count,
+      one: 'Mark 1 notification as read?',
+      other: 'Mark $count notifications as read?',
+      name: 'markSelectedNotificationsAsRead',
+      desc: '',
+      args: [count],
+    );
+  }
 }
 
 class AppLocalizationDelegate extends LocalizationsDelegate<S> {

--- a/lib/l10n/intl_ar.arb
+++ b/lib/l10n/intl_ar.arb
@@ -431,5 +431,38 @@
   "phoneIsInvalid": "رقم الهاتف غير صالح",
   "addVerificationMethod": "إضافة طريقة تحقق",
   "areYouSureYouWantToExit": "هل أنت متأكد أنك تريد الخروج؟",
-  "confirmToCloseTheApp": "تأكيد لإغلاق التطبيق"
+  "confirmToCloseTheApp": "تأكيد لإغلاق التطبيق",
+  "nSelected": "{count} محدد",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "تحديد الكل المحمّل",
+  "failedToPerformOperation": "{count, plural, =1{فشلت عملية واحدة} other{فشلت {count} عمليات}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{حذف إشعار واحد؟} other{حذف {count} إشعارات؟}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{وضع علامة مقروء لإشعار واحد؟} other{وضع علامة مقروء لـ {count} إشعارات؟}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_da_DK.arb
+++ b/lib/l10n/intl_da_DK.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Tilføj verifikationsmetode",
   "areYouSureYouWantToExit": "Er du sikker på, at du vil afslutte?",
   "confirmToCloseTheApp": "Bekræft for at lukke appen",
-  "loginNotification": "Log ind på din konto"
+  "loginNotification": "Log ind på din konto",
+  "nSelected": "{count} valgt",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Vælg alle indlæste",
+  "failedToPerformOperation": "{count, plural, =1{1 handling mislykkedes} other{{count} handlinger mislykkedes}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Slet 1 notifikation?} other{Slet {count} notifikationer?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Markér 1 notifikation som læst?} other{Markér {count} notifikationer som læst?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_de_DE.arb
+++ b/lib/l10n/intl_de_DE.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Verifizierungsmethode hinzufügen",
   "areYouSureYouWantToExit": "Möchten Sie wirklich beenden?",
   "confirmToCloseTheApp": "Bestätigen Sie, um die App zu schließen",
-  "loginNotification": "Melden Sie sich bei Ihrem Konto an"
+  "loginNotification": "Melden Sie sich bei Ihrem Konto an",
+  "nSelected": "{count} ausgewählt",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Alle geladenen auswählen",
+  "failedToPerformOperation": "{count, plural, =1{1 Vorgang fehlgeschlagen} other{{count} Vorgänge fehlgeschlagen}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{1 Benachrichtigung löschen?} other{{count} Benachrichtigungen löschen?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{1 Benachrichtigung als gelesen markieren?} other{{count} Benachrichtigungen als gelesen markieren?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_el_GR.arb
+++ b/lib/l10n/intl_el_GR.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Προσθήκη μεθόδου επαλήθευσης",
   "areYouSureYouWantToExit": "Είστε σίγουροι ότι θέλετε να βγείτε;",
   "confirmToCloseTheApp": "Επιβεβαίωση για κλείσιμο της εφαρμογής",
-  "loginNotification": "Συνδεθείτε στον λογαριασμό σας"
+  "loginNotification": "Συνδεθείτε στον λογαριασμό σας",
+  "nSelected": "{count} επιλεγμένα",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Επιλογή όλων των φορτωμένων",
+  "failedToPerformOperation": "{count, plural, =1{1 ενέργεια απέτυχε} other{{count} ενέργειες απέτυχαν}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Διαγραφή 1 ειδοποίησης;} other{Διαγραφή {count} ειδοποιήσεων;}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Σήμανση 1 ειδοποίησης ως αναγνωσμένης;} other{Σήμανση {count} ειδοποιήσεων ως αναγνωσμένων;}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -439,5 +439,38 @@
   "areYouSureYouWantToExit": "Are you sure you want to exit?",
   "confirmToCloseTheApp": "Confirm to close the app",
   "imageSavedToGallery": "Saved to platform 'Image gallery'",
-  "failedToSaveImage": "Failed to save image"
+  "failedToSaveImage": "Failed to save image",
+  "nSelected": "{count} selected",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Select all loaded",
+  "failedToPerformOperation": "{count, plural, =1{1 operation failed} other{{count} operations failed}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Delete 1 notification?} other{Delete {count} notifications?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Mark 1 notification as read?} other{Mark {count} notifications as read?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_es_ES.arb
+++ b/lib/l10n/intl_es_ES.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Añadir método de verificación",
   "areYouSureYouWantToExit": "¿Estás seguro de que quieres salir?",
   "confirmToCloseTheApp": "Confirmar para cerrar la aplicación",
-  "loginNotification": "Inicia sesión en tu cuenta"
+  "loginNotification": "Inicia sesión en tu cuenta",
+  "nSelected": "{count} seleccionados",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Seleccionar todo lo cargado",
+  "failedToPerformOperation": "{count, plural, =1{1 operación falló} other{{count} operaciones fallaron}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{¿Eliminar 1 notificación?} other{¿Eliminar {count} notificaciones?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{¿Marcar 1 notificación como leída?} other{¿Marcar {count} notificaciones como leídas?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_fr_FR.arb
+++ b/lib/l10n/intl_fr_FR.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Ajouter une méthode de vérification",
   "areYouSureYouWantToExit": "Êtes-vous sûr de vouloir quitter ?",
   "confirmToCloseTheApp": "Confirmer pour fermer l'application",
-  "loginNotification": "Connectez-vous à votre compte"
+  "loginNotification": "Connectez-vous à votre compte",
+  "nSelected": "{count} sélectionnés",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Sélectionner tout le chargé",
+  "failedToPerformOperation": "{count, plural, =1{1 opération a échoué} other{{count} opérations ont échoué}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Supprimer 1 notification ?} other{Supprimer {count} notifications ?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Marquer 1 notification comme lue ?} other{Marquer {count} notifications comme lues ?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_it_IT.arb
+++ b/lib/l10n/intl_it_IT.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Aggiungi metodo di verifica",
   "areYouSureYouWantToExit": "Sei sicuro di voler uscire?",
   "confirmToCloseTheApp": "Conferma per chiudere l'app",
-  "loginNotification": "Accedi al tuo account"
+  "loginNotification": "Accedi al tuo account",
+  "nSelected": "{count} selezionati",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Seleziona tutti i caricati",
+  "failedToPerformOperation": "{count, plural, =1{1 operazione non riuscita} other{{count} operazioni non riuscite}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Eliminare 1 notifica?} other{Eliminare {count} notifiche?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Segnare 1 notifica come letta?} other{Segnare {count} notifiche come lette?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_nl_NL.arb
+++ b/lib/l10n/intl_nl_NL.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Verificatiemethode toevoegen",
   "areYouSureYouWantToExit": "Weet u zeker dat u wilt afsluiten?",
   "confirmToCloseTheApp": "Bevestig om de app te sluiten",
-  "loginNotification": "Log in op uw account"
+  "loginNotification": "Log in op uw account",
+  "nSelected": "{count} geselecteerd",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Alle geladen selecteren",
+  "failedToPerformOperation": "{count, plural, =1{1 bewerking mislukt} other{{count} bewerkingen mislukt}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{1 melding verwijderen?} other{{count} meldingen verwijderen?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{1 melding als gelezen markeren?} other{{count} meldingen als gelezen markeren?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_no_NO.arb
+++ b/lib/l10n/intl_no_NO.arb
@@ -432,5 +432,38 @@
   "addVerificationMethod": "Legg til verifiseringsmetode",
   "areYouSureYouWantToExit": "Er du sikker på at du vil avslutte?",
   "confirmToCloseTheApp": "Bekreft for å lukke appen",
-  "loginNotification": "Logg inn på kontoen din"
+  "loginNotification": "Logg inn på kontoen din",
+  "nSelected": "{count} valgt",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Velg alle lastede",
+  "failedToPerformOperation": "{count, plural, =1{1 handling mislyktes} other{{count} handlinger mislyktes}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Slette 1 varsling?} other{Slette {count} varslinger?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Markere 1 varsling som lest?} other{Markere {count} varslinger som lest?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_vi_VN.arb
+++ b/lib/l10n/intl_vi_VN.arb
@@ -431,5 +431,38 @@
   "phoneIsInvalid": "Số điện thoại không hợp lệ",
   "addVerificationMethod": "Thêm phương thức xác minh",
   "areYouSureYouWantToExit": "Bạn có chắc chắn muốn thoát?",
-  "confirmToCloseTheApp": "Xác nhận để đóng ứng dụng"
+  "confirmToCloseTheApp": "Xác nhận để đóng ứng dụng",
+  "nSelected": "{count} đã chọn",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "Chọn tất cả đã tải",
+  "failedToPerformOperation": "{count, plural, =1{1 thao tác thất bại} other{{count} thao tác thất bại}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{Xóa 1 thông báo?} other{Xóa {count} thông báo?}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{Đánh dấu 1 thông báo đã đọc?} other{Đánh dấu {count} thông báo đã đọc?}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_zh_CN.arb
+++ b/lib/l10n/intl_zh_CN.arb
@@ -431,5 +431,38 @@
   "phoneIsInvalid": "手机号码无效",
   "addVerificationMethod": "添加验证方式",
   "areYouSureYouWantToExit": "您确定要退出吗？",
-  "confirmToCloseTheApp": "确认关闭应用"
+  "confirmToCloseTheApp": "确认关闭应用",
+  "nSelected": "已选择 {count} 项",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "全选已加载",
+  "failedToPerformOperation": "{count, plural, =1{1 项操作失败} other{{count} 项操作失败}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{删除 1 条通知？} other{删除 {count} 条通知？}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{将 1 条通知标记为已读？} other{将 {count} 条通知标记为已读？}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/l10n/intl_zh_TW.arb
+++ b/lib/l10n/intl_zh_TW.arb
@@ -431,5 +431,38 @@
   "phoneIsInvalid": "手機號碼無效",
   "addVerificationMethod": "新增驗證方式",
   "areYouSureYouWantToExit": "您確定要退出嗎？",
-  "confirmToCloseTheApp": "確認關閉應用程式"
+  "confirmToCloseTheApp": "確認關閉應用程式",
+  "nSelected": "已選擇 {count} 項",
+  "@nSelected": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "selectAll": "全選已載入",
+  "failedToPerformOperation": "{count, plural, =1{1 項操作失敗} other{{count} 項操作失敗}}",
+  "@failedToPerformOperation": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "deleteSelectedNotifications": "{count, plural, =1{刪除 1 則通知？} other{刪除 {count} 則通知？}}",
+  "@deleteSelectedNotifications": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  },
+  "markSelectedNotificationsAsRead": "{count, plural, =1{將 1 則通知標記為已讀？} other{將 {count} 則通知標記為已讀？}}",
+  "@markSelectedNotificationsAsRead": {
+    "placeholders": {
+      "count": {
+        "type": "int"
+      }
+    }
+  }
 }

--- a/lib/modules/notification/notification_page.dart
+++ b/lib/modules/notification/notification_page.dart
@@ -1,6 +1,7 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
+import 'package:thingsboard_app/config/themes/app_colors.dart';
 import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/notification/controllers/notification_query_ctrl.dart';
@@ -13,7 +14,6 @@ import 'package:thingsboard_app/modules/notification/widgets/notification_list.d
 import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
-import 'package:thingsboard_app/utils/services/overlay_service/overlay_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/widgets/tb_app_bar.dart';
 
@@ -33,96 +33,400 @@ class _NotificationPageState extends State<NotificationPage> {
   late final NotificationRepository notificationRepository;
   final overlayService = getIt<IOverlayService>();
   late final StreamSubscription<int> listener;
+
+  bool isSelectionMode = false;
+  Set<String> selectedIds = {};
+  bool isProcessing = false;
+  bool _cancelRequested = false;
+  int processedCount = 0;
+  int totalToProcess = 0;
+
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: TbAppBar(
-        title: Text(S.of(context).notifications(2)),
-        actions: [
-          TextButton(
-            child: Text(
-              S.of(context).markAllAsRead,
-              style: TextStyle(color: Theme.of(context).primaryColor),
-            ),
-            onPressed: () async {
-              await notificationRepository.markAllAsRead();
+    return PopScope(
+      canPop: !isSelectionMode,
+      onPopInvokedWithResult: (didPop, _) {
+        if (!didPop && isSelectionMode) {
+          _exitSelectionMode();
+        }
+      },
+      child: Scaffold(
+        appBar: isSelectionMode ? _buildSelectionAppBar() : _buildNormalAppBar(),
+        body: RefreshIndicator(
+          onRefresh: () => _refresh(),
+          child: SafeArea(
+            child: Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 10),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  Padding(
+                    padding: const EdgeInsets.only(top: 10, bottom: 20),
+                    child: FilterSegmentedButton(
+                      selected: notificationsFilter,
+                      onSelectionChanged: (newSelection) {
+                        if (notificationsFilter == newSelection) {
+                          return;
+                        }
 
-              if (mounted) {
-                notificationQueryCtrl.refresh();
-              }
-            },
-          ),
-        ],
-      ),
-      body: RefreshIndicator(
-        onRefresh: () => _refresh(),
-        child: SafeArea(
-          child: Padding(
-            padding: const EdgeInsets.symmetric(horizontal: 5, vertical: 10),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                Padding(
-                  padding: const EdgeInsets.only(top: 10, bottom: 20),
-                  child: FilterSegmentedButton(
-                    selected: notificationsFilter,
-                    onSelectionChanged: (newSelection) {
-                      if (notificationsFilter == newSelection) {
-                        return;
-                      }
+                        _exitSelectionMode();
+                        setState(() {
+                          notificationsFilter = newSelection;
 
-                      setState(() {
-                        notificationsFilter = newSelection;
-
-                        notificationRepository.filterByReadStatus(
-                          notificationsFilter == NotificationsFilter.unread,
-                        );
-                      });
-                    },
-                    segments: [
-                      FilterSegments(
-                        label: S.of(context).unread,
-                        value: NotificationsFilter.unread,
-                      ),
-                      FilterSegments(
-                        label: S.of(context).all,
-                        value: NotificationsFilter.all,
-                      ),
-                    ],
+                          notificationRepository.filterByReadStatus(
+                            notificationsFilter == NotificationsFilter.unread,
+                          );
+                        });
+                      },
+                      segments: [
+                        FilterSegments(
+                          label: S.of(context).unread,
+                          value: NotificationsFilter.unread,
+                        ),
+                        FilterSegments(
+                          label: S.of(context).all,
+                          value: NotificationsFilter.all,
+                        ),
+                      ],
+                    ),
                   ),
-                ),
-                Expanded(
-                  child: NotificationsList(
-                    pagingController: paginationRepository.pagingController,
-                    thingsboardClient: getIt<ITbClientService>().client,
-                    onClearNotification: (id, read) async {
-                      await notificationRepository.deleteNotification(id);
-                      if (!read) {
+                  Expanded(
+                    child: NotificationsList(
+                      pagingController: paginationRepository.pagingController,
+                      thingsboardClient: getIt<ITbClientService>().client,
+                      isSelectionMode: isSelectionMode,
+                      selectedIds: selectedIds,
+                      onToggleSelection: _toggleSelection,
+                      onLongPress: _enterSelectionMode,
+                      onClearNotification: (id, read) async {
+                        await notificationRepository.deleteNotification(id);
+                        if (!read) {
+                          await notificationRepository
+                              .decreaseNotificationBadgeCount();
+                        }
+
+                        if (mounted) {
+                          notificationQueryCtrl.refresh();
+                        }
+                      },
+                      onReadNotification: (id) async {
+                        await notificationRepository.markNotificationAsRead(id);
                         await notificationRepository
                             .decreaseNotificationBadgeCount();
-                      }
 
-                      if (mounted) {
-                        notificationQueryCtrl.refresh();
-                      }
-                    },
-                    onReadNotification: (id) async {
-                      await notificationRepository.markNotificationAsRead(id);
-                      await notificationRepository
-                          .decreaseNotificationBadgeCount();
+                        if (mounted) {
+                          notificationQueryCtrl.refresh();
+                        }
+                      },
+                    ),
+                  ),
+                ],
+              ),
+            ),
+          ),
+        ),
+        bottomNavigationBar:
+            isSelectionMode ? _buildSelectionActionBar() : null,
+      ),
+    );
+  }
 
-                      if (mounted) {
-                        notificationQueryCtrl.refresh();
-                      }
-                    },
+  TbAppBar _buildNormalAppBar() {
+    return TbAppBar(
+      title: Text(S.of(context).notifications(2)),
+      actions: [
+        TextButton(
+          child: Text(
+            S.of(context).markAllAsRead,
+            style: TextStyle(color: Theme.of(context).primaryColor),
+          ),
+          onPressed: () async {
+            await notificationRepository.markAllAsRead();
+
+            if (mounted) {
+              notificationQueryCtrl.refresh();
+            }
+          },
+        ),
+      ],
+    );
+  }
+
+  TbAppBar _buildSelectionAppBar() {
+    final allSelected = _allSelected;
+    return TbAppBar(
+      canGoBack: false,
+      leading: IconButton(
+        icon: const Icon(Icons.close),
+        onPressed: _exitSelectionMode,
+      ),
+      title: Text(S.of(context).nSelected(selectedIds.length)),
+      actions: [
+        Row(
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Checkbox(
+              value: allSelected,
+              onChanged: (_) {
+                if (allSelected) {
+                  _exitSelectionMode();
+                } else {
+                  _selectAll();
+                }
+              },
+            ),
+            Padding(
+              padding: const EdgeInsets.only(right: 8),
+              child: GestureDetector(
+                onTap: () {
+                  if (allSelected) {
+                    _exitSelectionMode();
+                  } else {
+                    _selectAll();
+                  }
+                },
+                child: Text(
+                  S.of(context).selectAll,
+                  style: TextStyle(color: Theme.of(context).primaryColor),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ],
+    );
+  }
+
+  Widget _buildSelectionActionBar() {
+    return SafeArea(
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          if (isProcessing)
+            LinearProgressIndicator(
+              value: totalToProcess > 0 ? processedCount / totalToProcess : null,
+            ),
+          Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+            child: Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
+                        isProcessing || selectedIds.isEmpty
+                            ? null
+                            : _batchDelete,
+                    icon: const Icon(Icons.delete_outline),
+                    label: Text(S.of(context).delete),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: AppColors.notificationError,
+                      side: BorderSide(
+                        color:
+                            isProcessing || selectedIds.isEmpty
+                                ? Colors.grey.shade300
+                                : AppColors.notificationError,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed:
+                        isProcessing || selectedIds.isEmpty || !_hasUnreadSelected
+                            ? null
+                            : _batchMarkAsRead,
+                    icon: const Icon(Icons.check_circle_outline),
+                    label: Text(S.of(context).markAsRead),
+                    style: OutlinedButton.styleFrom(
+                      foregroundColor: AppColors.notificationSuccess,
+                      side: BorderSide(
+                        color:
+                            isProcessing || selectedIds.isEmpty || !_hasUnreadSelected
+                                ? Colors.grey.shade300
+                                : AppColors.notificationSuccess,
+                      ),
+                    ),
                   ),
                 ),
               ],
             ),
           ),
-        ),
+        ],
       ),
     );
+  }
+
+  void _enterSelectionMode(String id) {
+    if (isSelectionMode) return;
+    setState(() {
+      isSelectionMode = true;
+      selectedIds = {id};
+    });
+  }
+
+  void _exitSelectionMode() {
+    if (!isSelectionMode) return;
+    setState(() {
+      isSelectionMode = false;
+      selectedIds = {};
+      if (isProcessing) {
+        _cancelRequested = true;
+      }
+    });
+  }
+
+  void _toggleSelection(String id) {
+    setState(() {
+      if (selectedIds.contains(id)) {
+        selectedIds.remove(id);
+        if (selectedIds.isEmpty) {
+          isSelectionMode = false;
+        }
+      } else {
+        selectedIds.add(id);
+      }
+    });
+  }
+
+  void _selectAll() {
+    final items = paginationRepository.pagingController.itemList;
+    if (items == null || items.isEmpty) return;
+    setState(() {
+      selectedIds = items.map((n) => n.id!.id!).toSet();
+    });
+  }
+
+  bool get _allSelected {
+    final items = paginationRepository.pagingController.itemList;
+    if (items == null || items.isEmpty) return false;
+    return selectedIds.length == items.length;
+  }
+
+  bool get _hasUnreadSelected {
+    final items = paginationRepository.pagingController.itemList;
+    if (items == null || items.isEmpty) return false;
+    return items.any(
+      (n) =>
+          selectedIds.contains(n.id!.id!) &&
+          n.status != PushNotificationStatus.READ,
+    );
+  }
+
+  Future<void> _batchDelete() async {
+    final count = selectedIds.length;
+    final confirmed = await overlayService.showConfirmDialog(
+      content: (_) => DialogContent(
+        title: S.of(context).areYouSure,
+        message: S.of(context).deleteSelectedNotifications(count),
+        ok: S.of(context).delete,
+        cancel: S.of(context).no,
+      ),
+    );
+    if (confirmed != true) return;
+
+    final items = paginationRepository.pagingController.itemList ?? [];
+    final toDelete =
+        items.where((n) => selectedIds.contains(n.id!.id!)).toList();
+
+    setState(() {
+      isProcessing = true;
+      processedCount = 0;
+      totalToProcess = toDelete.length;
+    });
+
+    int unreadCount = 0;
+    int failCount = 0;
+    for (final notification in toDelete) {
+      if (_cancelRequested) break;
+      try {
+        await notificationRepository.deleteNotification(notification.id!.id!);
+        if (notification.status != PushNotificationStatus.READ) {
+          unreadCount++;
+        }
+      } catch (_) {
+        failCount++;
+      }
+      if (mounted) setState(() => processedCount++);
+    }
+
+    for (int i = 0; i < unreadCount; i++) {
+      await notificationRepository.decreaseNotificationBadgeCount();
+    }
+
+    if (mounted) {
+      if (!_cancelRequested) {
+        _exitSelectionMode();
+      }
+      setState(() {
+        isProcessing = false;
+        _cancelRequested = false;
+      });
+      notificationQueryCtrl.refresh();
+
+      if (failCount > 0) {
+        overlayService.showWarnNotification(
+          (_) => S.of(context).failedToPerformOperation(failCount),
+        );
+      }
+    }
+  }
+
+  Future<void> _batchMarkAsRead() async {
+    final items = paginationRepository.pagingController.itemList ?? [];
+    final toMark = items
+        .where(
+          (n) =>
+              selectedIds.contains(n.id!.id!) &&
+              n.status != PushNotificationStatus.READ,
+        )
+        .toList();
+
+    final confirmed = await overlayService.showConfirmDialog(
+      content: (_) => DialogContent(
+        title: S.of(context).areYouSure,
+        message: S.of(context).markSelectedNotificationsAsRead(toMark.length),
+        ok: S.of(context).markAsRead,
+        cancel: S.of(context).no,
+      ),
+    );
+    if (confirmed != true) return;
+
+    setState(() {
+      isProcessing = true;
+      processedCount = 0;
+      totalToProcess = toMark.length;
+    });
+
+    int failCount = 0;
+    for (final notification in toMark) {
+      if (_cancelRequested) break;
+      try {
+        await notificationRepository
+            .markNotificationAsRead(notification.id!.id!);
+        await notificationRepository.decreaseNotificationBadgeCount();
+      } catch (_) {
+        failCount++;
+      }
+      if (mounted) setState(() => processedCount++);
+    }
+
+    if (mounted) {
+      if (!_cancelRequested) {
+        _exitSelectionMode();
+      }
+      setState(() {
+        isProcessing = false;
+        _cancelRequested = false;
+      });
+      notificationQueryCtrl.refresh();
+
+      if (failCount > 0) {
+        overlayService.showWarnNotification(
+          (_) => S.of(context).failedToPerformOperation(failCount),
+        );
+      }
+    }
   }
 
   @override
@@ -177,6 +481,7 @@ class _NotificationPageState extends State<NotificationPage> {
   }
 
   Future<void> _refresh() async {
+    _exitSelectionMode();
     if (mounted) {
       notificationQueryCtrl.refresh();
     }

--- a/lib/modules/notification/widgets/notification_list.dart
+++ b/lib/modules/notification/widgets/notification_list.dart
@@ -12,13 +12,20 @@ class NotificationsList extends StatelessWidget {
     required this.thingsboardClient,
     required this.onClearNotification,
     required this.onReadNotification,
-
+    this.isSelectionMode = false,
+    this.selectedIds = const {},
+    this.onToggleSelection,
+    this.onLongPress,
     super.key,
   });
 
   final ThingsboardClient thingsboardClient;
   final Function(String id, bool read) onClearNotification;
   final ValueChanged<String> onReadNotification;
+  final bool isSelectionMode;
+  final Set<String> selectedIds;
+  final ValueChanged<String>? onToggleSelection;
+  final ValueChanged<String>? onLongPress;
 
   final PagingController<PushNotificationQuery, PushNotification>
   pagingController;
@@ -29,17 +36,22 @@ class NotificationsList extends StatelessWidget {
       pagingController: pagingController,
       builderDelegate: PagedChildBuilderDelegate(
         itemBuilder: (context, item, index) {
+          final id = item.id!.id!;
           return NotificationSlidableWidget(
             notification: item,
             onReadNotification: onReadNotification,
             onClearNotification: onClearNotification,
-
+            isSelectionMode: isSelectionMode,
             thingsboardClient: thingsboardClient,
             child: NotificationWidget(
               notification: item,
               thingsboardClient: thingsboardClient,
               onClearNotification: onClearNotification,
               onReadNotification: onReadNotification,
+              isSelectionMode: isSelectionMode,
+              isSelected: selectedIds.contains(id),
+              onToggleSelection: () => onToggleSelection?.call(id),
+              onLongPress: () => onLongPress?.call(id),
             ),
           );
         },

--- a/lib/modules/notification/widgets/notification_slidable_widget.dart
+++ b/lib/modules/notification/widgets/notification_slidable_widget.dart
@@ -12,7 +12,7 @@ class NotificationSlidableWidget extends StatefulWidget {
     required this.thingsboardClient,
     required this.onClearNotification,
     required this.onReadNotification,
-
+    this.isSelectionMode = false,
     super.key,
   });
 
@@ -21,6 +21,7 @@ class NotificationSlidableWidget extends StatefulWidget {
   final ThingsboardClient thingsboardClient;
   final Function(String id, bool read) onClearNotification;
   final ValueChanged<String> onReadNotification;
+  final bool isSelectionMode;
 
   @override
   State<StatefulWidget> createState() => _NotificationSlidableWidget();
@@ -37,6 +38,10 @@ class _NotificationSlidableWidget extends State<NotificationSlidableWidget> {
         alignment: Alignment.center,
         child: const RefreshProgressIndicator(),
       );
+    }
+
+    if (widget.isSelectionMode) {
+      return widget.child;
     }
 
     return Slidable(

--- a/lib/modules/notification/widgets/notification_widget.dart
+++ b/lib/modules/notification/widgets/notification_widget.dart
@@ -15,7 +15,10 @@ class NotificationWidget extends StatelessWidget {
     required this.thingsboardClient,
     required this.onClearNotification,
     required this.onReadNotification,
-
+    this.isSelectionMode = false,
+    this.isSelected = false,
+    this.onToggleSelection,
+    this.onLongPress,
     super.key,
   });
 
@@ -23,6 +26,10 @@ class NotificationWidget extends StatelessWidget {
   final ThingsboardClient thingsboardClient;
   final Function(String id, bool readed) onClearNotification;
   final ValueChanged<String> onReadNotification;
+  final bool isSelectionMode;
+  final bool isSelected;
+  final VoidCallback? onToggleSelection;
+  final VoidCallback? onLongPress;
 
   @override
   Widget build(BuildContext context) {
@@ -33,11 +40,14 @@ class NotificationWidget extends StatelessWidget {
     final severity = notification.info?.alarmSeverity;
 
     return InkWell(
-      onTap: () {
-        getIt<HandleNotificationTapUsecase>().call(
-          HandleNotificationTapParams(notification: notification),
-        );
-      },
+      onTap: isSelectionMode
+          ? onToggleSelection
+          : () {
+              getIt<HandleNotificationTapUsecase>().call(
+                HandleNotificationTapParams(notification: notification),
+              );
+            },
+      onLongPress: onLongPress,
       child: Container(
         padding: const EdgeInsets.symmetric(horizontal: 15, vertical: 10),
         decoration: BoxDecoration(
@@ -59,6 +69,14 @@ class NotificationWidget extends StatelessWidget {
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               crossAxisAlignment: CrossAxisAlignment.start,
               children: [
+                if (isSelectionMode)
+                  Padding(
+                    padding: const EdgeInsets.only(right: 4),
+                    child: Checkbox(
+                      value: isSelected,
+                      onChanged: (_) => onToggleSelection?.call(),
+                    ),
+                  ),
                 Column(
                   children: [NotificationIcon(notification: notification)],
                 ),
@@ -105,15 +123,20 @@ class NotificationWidget extends StatelessWidget {
                           child: SizedBox(
                             width: 30,
                             height: 50,
-                            child: IconButton(
-                              onPressed:
-                                  () =>
-                                      onReadNotification(notification.id!.id!),
-                              icon: Icon(
-                                Icons.check_circle_outline,
-                                color: Colors.black.withValues(alpha: 0.38),
-                              ),
-                            ),
+                            child: isSelectionMode
+                                ? Icon(
+                                    Icons.check_circle_outline,
+                                    color: Colors.black.withValues(alpha: 0.38),
+                                  )
+                                : IconButton(
+                                    onPressed:
+                                        () =>
+                                            onReadNotification(notification.id!.id!),
+                                    icon: Icon(
+                                      Icons.check_circle_outline,
+                                      color: Colors.black.withValues(alpha: 0.38),
+                                    ),
+                                  ),
                           ),
                         ),
                         Visibility(


### PR DESCRIPTION
## Summary
- Adds multi-select mode to the Notifications tab (long-press to enter)
- App bar switches to show selected count, Select All loaded checkbox, and close button
- Bottom action bar with batch **Delete** and **Mark as Read** buttons
- Confirmation dialogs and determinate progress indicator for batch operations
- Slidable swipe actions are disabled during selection mode
- Selection mode exits on back press, filter change, or pull-to-refresh
- Cancellable batch operations with failure count feedback
- Mark as Read disabled when all selected items are already read

## Test plan
- [ ] Long-press a notification → enters selection mode with item checked
- [ ] Tap notifications to toggle selection checkboxes
- [ ] Tap "Select all loaded" → all loaded items selected
- [ ] Tap "Delete" → confirmation dialog, then selected notifications deleted, badge count updated
- [ ] Tap "Mark as Read" → confirmation dialog, then selected unread notifications marked as read
- [ ] Press X or system back → exits selection mode
- [ ] Switch between All/Unread filter → exits selection mode
- [ ] Pull-to-refresh → exits selection mode
- [ ] Exiting during a running batch operation cancels it