### PR TITLE
fix(profile): restore language on edit cancel and rebuild on language change

### DIFF
--- a/lib/modules/profile/widget/profile_edit_page.dart
+++ b/lib/modules/profile/widget/profile_edit_page.dart
@@ -36,6 +36,9 @@ class ProfileEditPage extends HookConsumerWidget {
     final allLanguages = useMemoized(() => getAllLanguages(context));
     final canPop = useState(true);
 
+    final initialLocale = useMemoized(() => getCurrentLocale(context, user));
+    final selectedLocale = useState<Locale>(initialLocale);
+
     final form = useMemoized(
       () => FormGroup({
         "email": FormControl(
@@ -97,7 +100,16 @@ class ProfileEditPage extends HookConsumerWidget {
         initialValue: PhoneNumber(isoCode: IsoCode.fromJson('US'), nsn: ''),
       ),
     );
-    return Scaffold(
+    return PopScope(
+      canPop: canPop.value,
+      onPopInvokedWithResult: (didPop, result) async {
+        if (didPop) return;
+        final cancel = await onCancelEditing(context);
+        if (cancel && context.mounted) {
+          await _setLanguageAndNavigate(context, initialLocale, context.pop);
+        }
+      },
+      child: Scaffold(
       appBar: TbAppBar(
         title: Text(
           '${S.of(context).edit} ${S.of(context).profile.toLowerCase()}',
@@ -107,7 +119,7 @@ class ProfileEditPage extends HookConsumerWidget {
             if (!canPop.value) {
               final cancel = await onCancelEditing(context);
               if (cancel && context.mounted) {
-                context.pop();
+                await _setLanguageAndNavigate(context, initialLocale, context.pop);
               }
             } else {
               if (context.mounted) {
@@ -253,7 +265,12 @@ class ProfileEditPage extends HookConsumerWidget {
                                     child: TbDropDownTextField<Locale>(
                                       formControlName: 'additionalInfo.lang',
                                       label: S.of(context).language,
-                                      onSelected: (val) => S.load(val!),
+                                      onSelected: (val) async {
+                                        await S.load(val!);
+                                        if (context.mounted) {
+                                          selectedLocale.value = val;
+                                        }
+                                      },
                                       selectedItemBuilder:
                                           (val) => getLocalizedLanguageName(
                                             val!,
@@ -395,7 +412,7 @@ class ProfileEditPage extends HookConsumerWidget {
                                 canPop.value
                                     ? null
                                     : () async {
-                                      await onDiscardPressed(context);
+                                      await onDiscardPressed(context, initialLocale);
                                     },
                             child: Text(S.of(context).discardChanges),
                           ),
@@ -412,6 +429,7 @@ class ProfileEditPage extends HookConsumerWidget {
             ),
           ],
         ),
+      ),
       ),
     );
   }
@@ -439,7 +457,7 @@ class ProfileEditPage extends HookConsumerWidget {
     }
   }
 
-  Future<void> onDiscardPressed(BuildContext context) async {
+  Future<void> onDiscardPressed(BuildContext context, Locale initialLocale) async {
     final original = S.of(context).discardChanges;
     String titleString = original;
     if (original.isNotEmpty) {
@@ -477,7 +495,11 @@ class ProfileEditPage extends HookConsumerWidget {
           ),
     );
     if (discard == true && context.mounted) {
-      context.pushReplacement('/profile/edit');
+      await _setLanguageAndNavigate(
+        context,
+        initialLocale,
+        () => context.pushReplacement('/profile/edit'),
+      );
     }
   }
 }
@@ -544,4 +566,13 @@ Future<bool> onCancelEditing(BuildContext context) async {
 
 String getCountryDisplayName(Country? country) {
   return '${country?.flagEmoji} ${country?.name}';
+}
+
+Future<void> _setLanguageAndNavigate(
+  BuildContext context,
+  Locale locale,
+  VoidCallback navigate,
+) async {
+  await S.load(locale);
+  if (context.mounted) navigate();
 }


### PR DESCRIPTION
## Summary
- **Bug 1 — Second language selection did not update the UI.** Picking a different language a second time changed `Intl.defaultLocale` via `S.load()` but the page didn't rebuild, because the only state change (`canPop` going from `true` to `false`) had already happened on the first edit.
- **Bug 2 — Unsaved language leaked into the rest of the app.** Closing or discarding the Edit Profile page without saving left `Intl.defaultLocale` set to the picked language. The Profile page and More tab rendered in the new language until `loadUser()` ran again (e.g. on Settings navigation).
- **Bug 3 — System back gesture bypassed the unsaved-changes confirmation.** The Close button checked `canPop`, but Android back / swipe-back popped the route silently.

## Fix
- Capture `initialLocale` on mount and restore it on every non-save exit:
  - Close button confirm
  - Discard Changes confirm
  - System back gesture (now intercepted via `PopScope` using the existing `canPop` state)
- Track the picked locale in a `useState<Locale>` so each selection forces a `build()`, ensuring all `S.of(context)` strings reflect the new language.
- Extract a small file-private helper `_setLanguageAndNavigate(context, locale, navigate)` to encapsulate the `S.load` + mount-check + navigation pattern reused at all exit points.

## Test plan
- [ ] Open Edit Profile, pick a language → UI updates to that language.
- [ ] Without leaving the page, pick a different language → UI updates again.
- [ ] Pick a new language, tap Close → confirm → Profile and More tabs are in the original language.
- [ ] Pick a new language, swipe/system-back → confirmation dialog appears (was previously bypassed).
- [ ] Pick a new language, tap Discard Changes → confirm → form resets to original language and UI is in original language.
- [ ] Pick a new language, tap Apply Changes → success notification, language persists across navigation.