### PR TITLE
fix: stop push notifications after session expires without explicit logout

### DIFF
--- a/lib/constants/database_keys.dart
+++ b/lib/constants/database_keys.dart
@@ -2,4 +2,5 @@ abstract final class DatabaseKeys {
   static const thingsBoardApiEndpointKey = 'thingsBoardApiEndpoint';
   static const initialAppLink = 'initialAppLink';
   static const selectedRegion = 'selectedRegion';
+  static const pushNotificationsRegistered = 'push_notifications_registered';
 }

--- a/lib/constants/database_keys.dart
+++ b/lib/constants/database_keys.dart
@@ -2,5 +2,5 @@ abstract final class DatabaseKeys {
   static const thingsBoardApiEndpointKey = 'thingsBoardApiEndpoint';
   static const initialAppLink = 'initialAppLink';
   static const selectedRegion = 'selectedRegion';
-  static const pushNotificationsRegistered = 'push_notifications_registered';
+  static const pushNotificationsRegistered = 'pushNotificationsRegistered';
 }

--- a/lib/core/auth/login/provider/login_provider.dart
+++ b/lib/core/auth/login/provider/login_provider.dart
@@ -51,6 +51,9 @@ class Login extends _$Login {
     log('handle user loaded: ${_tbClient.getAuthUser()?.userId}');
 
     if (!_tbClient.isAuthenticated()) {
+      if (getIt<IFirebaseService>().apps.isNotEmpty) {
+        await getIt<NotificationService>().handleSessionExpired();
+      }
       state = const LoginState(isUserLoaded: false);
       return;
     }

--- a/lib/core/auth/login/provider/login_provider.dart
+++ b/lib/core/auth/login/provider/login_provider.dart
@@ -13,7 +13,6 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/utils/services/communication/events/user_loaded_event.dart';
 import 'package:thingsboard_app/utils/services/communication/i_communication_service.dart';
 import 'package:thingsboard_app/utils/services/device_info/i_device_info_service.dart';
-import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
 import 'package:thingsboard_app/utils/services/notification_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
@@ -40,8 +39,7 @@ class Login extends _$Login {
   }
 
   Future<void> logout() async {
-    if (getIt<IFirebaseService>().apps.isNotEmpty &&
-        state.isFullyAuthenticated()) {
+    if (state.isFullyAuthenticated()) {
       await getIt<NotificationService>().logout();
     }
     await _tbClient.logout(requestConfig: RequestConfig(ignoreErrors: true));
@@ -51,10 +49,11 @@ class Login extends _$Login {
     log('handle user loaded: ${_tbClient.getAuthUser()?.userId}');
 
     if (!_tbClient.isAuthenticated()) {
-      if (getIt<IFirebaseService>().apps.isNotEmpty) {
-        await getIt<NotificationService>().handleSessionExpired();
-      }
       state = const LoginState(isUserLoaded: false);
+      // Fire-and-forget: the cleanup swallows its own errors, and the
+      // registration flag is deleted last, so an interrupted attempt is
+      // retried on the next launch without delaying the login screen.
+      unawaited(getIt<NotificationService>().cleanUpStalePushRegistration());
       return;
     }
     if (_tbClient.isPreVerificationToken() ||
@@ -116,9 +115,7 @@ class Login extends _$Login {
 
   Future<void> _onFullyLoggedIn() async {
     await loadUser();
-    if (getIt<IFirebaseService>().apps.isNotEmpty) {
-      await getIt<NotificationService>().init();
-    }
+    await getIt<NotificationService>().init();
   }
 
   Future<void> twoFaConfirmed(LoginResponse response) async {

--- a/lib/core/auth/login/provider/login_provider.dart
+++ b/lib/core/auth/login/provider/login_provider.dart
@@ -53,6 +53,8 @@ class Login extends _$Login {
       // Fire-and-forget: the cleanup swallows its own errors, and the
       // registration flag is deleted last, so an interrupted attempt is
       // retried on the next launch without delaying the login screen.
+      // NotificationService.init() waits for it, so a fast auto-login
+      // (QR code, OAuth2) cannot register a token while it is being deleted.
       unawaited(getIt<NotificationService>().cleanUpStalePushRegistration());
       return;
     }

--- a/lib/core/context/tb_context.dart
+++ b/lib/core/context/tb_context.dart
@@ -15,7 +15,6 @@ import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/utils/services/version_service/version_info.dart';
 import 'package:thingsboard_app/utils/services/device_info/i_device_info_service.dart';
 import 'package:thingsboard_app/utils/services/endpoint/i_endpoint_service.dart';
-import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
 import 'package:thingsboard_app/utils/services/notification_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 import 'package:thingsboard_app/utils/utils.dart';
@@ -303,9 +302,7 @@ class TbContext implements PopEntry {
     log.debug('TbContext::logout($requestConfig, $notifyUser)');
     _handleRootState = true;
 
-    if (getIt<IFirebaseService>().apps.isNotEmpty) {
-      await getIt<NotificationService>().init();
-    }
+    await getIt<NotificationService>().logout();
 
     await tbClient.logout(requestConfig: requestConfig, notifyUser: notifyUser);
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -24,7 +24,7 @@ Future<void> main() async {
       WidgetsFlutterBinding.ensureInitialized();
   FlutterNativeSplash.preserve(widgetsBinding: widgetsBinding);
   await Hive.initFlutter();
-         SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
+  SystemChrome.setSystemUIOverlayStyle(SystemUiOverlayStyle.dark);
   Hive.registerAdapter(RegionAdapter());
   await setUpRootDependencies();
   if (UniversalPlatform.isAndroid) {
@@ -34,7 +34,7 @@ Future<void> main() async {
   }
 
   try {
-    getIt<IFirebaseService>().initializeApp(
+    await getIt<IFirebaseService>().initializeApp(
       options: DefaultFirebaseOptions.currentPlatform,
     );
   } catch (e) {

--- a/lib/utils/services/local_database/i_local_database_service.dart
+++ b/lib/utils/services/local_database/i_local_database_service.dart
@@ -17,4 +17,10 @@ abstract interface class ILocalDatabaseService {
   Future<String?> getInitialAppLink();
 
   Future<void> deleteInitialAppLink();
+
+  Future<bool> isPushRegistered();
+
+  Future<void> setPushRegistered();
+
+  Future<void> clearPushRegistered();
 }

--- a/lib/utils/services/local_database/local_database_service.dart
+++ b/lib/utils/services/local_database/local_database_service.dart
@@ -47,8 +47,9 @@ class LocalDatabaseService implements ILocalDatabaseService {
   }
 
   @override
-  Future<bool> isPushRegistered() {
-    return storage.containsKey(DatabaseKeys.pushNotificationsRegistered);
+  Future<bool> isPushRegistered() async {
+    return await storage.getItem(DatabaseKeys.pushNotificationsRegistered) ==
+        true;
   }
 
   @override

--- a/lib/utils/services/local_database/local_database_service.dart
+++ b/lib/utils/services/local_database/local_database_service.dart
@@ -45,4 +45,19 @@ class LocalDatabaseService implements ILocalDatabaseService {
   Future<void> deleteInitialAppLink() {
     return storage.deleteItem(DatabaseKeys.initialAppLink);
   }
+
+  @override
+  Future<bool> isPushRegistered() {
+    return storage.containsKey(DatabaseKeys.pushNotificationsRegistered);
+  }
+
+  @override
+  Future<void> setPushRegistered() {
+    return storage.setItem(DatabaseKeys.pushNotificationsRegistered, true);
+  }
+
+  @override
+  Future<void> clearPushRegistered() {
+    return storage.deleteItem(DatabaseKeys.pushNotificationsRegistered);
+  }
 }

--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -55,6 +55,8 @@ class NotificationService {
     }
     // A stale cleanup started while unauthenticated may still be deleting the
     // FCM token; registering concurrently would delete the token just saved.
+    // This relies on the service being a locator singleton: the login
+    // provider started that cleanup on this same instance.
     await _staleCleanup;
 
     _log.debug('NotificationService::init()');
@@ -159,22 +161,37 @@ class NotificationService {
   /// local FCM token makes further pushes bounce, and the platform purges
   /// the session on the next delivery attempt.
   ///
-  /// Idempotent and safe to call whenever the client is unauthenticated.
-  /// Concurrent calls share a single run, and [init] waits for it to finish.
-  Future<void> cleanUpStalePushRegistration() {
+  /// Idempotent, never throws, and safe to call whenever the client is
+  /// unauthenticated. Concurrent calls share a single run, and [init] waits
+  /// for a run that is already in flight. The reverse direction is not
+  /// ordered: a cleanup that starts while [init] is mid-flight can delete the
+  /// token [init] just registered, which only costs pushes until the next
+  /// launch registers a fresh one.
+  Future<void> cleanUpStalePushRegistration() async {
     if (!_isFirebaseConfigured) {
-      return Future.value();
+      return;
     }
-    return _staleCleanup ??= _tearDownIfRegistered().whenComplete(
+    _staleCleanup ??= _tearDownIfRegistered().whenComplete(
       () => _staleCleanup = null,
     );
+    await _staleCleanup;
   }
 
   Future<void> _tearDownIfRegistered() async {
-    if (!await _localDatabase.isPushRegistered()) {
+    final bool registered;
+    try {
+      registered = await _localDatabase.isPushRegistered();
+    } catch (e) {
+      _log.warn(
+        'NotificationService::_tearDownIfRegistered() failed to read the '
+        'registration flag: $e',
+      );
       return;
     }
-    _log.debug('NotificationService::cleanUpStalePushRegistration()');
+    if (!registered) {
+      return;
+    }
+    _log.debug('NotificationService::_tearDownIfRegistered()');
     await _tearDownLocalPushState();
   }
 

--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -15,6 +15,8 @@ import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_ser
 import 'package:thingsboard_app/utils/utils.dart';
 
 class NotificationService {
+  static const _pushRegisteredKey = 'push_notifications_registered';
+
   static FirebaseMessaging _messaging = FirebaseMessaging.instance;
   late NotificationDetails _notificationDetails;
   final TbLogger _log = getIt();
@@ -98,9 +100,17 @@ class NotificationService {
       getIt<TbLogger>().debug(
         'NotificationService::logout() removeMobileSession',
       );
-      _tbClient.getUserControllerApi().removeMobileSession(
-        xMobileToken: _fcmToken!,
-      );
+      try {
+        await _tbClient.getUserControllerApi().removeMobileSession(
+          xMobileToken: _fcmToken!,
+        );
+      } catch (e) {
+        // Best effort: the session may already be invalid (e.g. expired JWT).
+        // Deleting the local FCM token below still stops the notifications.
+        getIt<TbLogger>().debug(
+          'NotificationService::logout() removeMobileSession failed: $e',
+        );
+      }
     }
 
     await _foregroundMessageSubscription?.cancel();
@@ -110,6 +120,28 @@ class NotificationService {
     await _messaging.setAutoInitEnabled(false);
     await flutterLocalNotificationsPlugin.cancelAll();
     await _localService.clearNotificationBadgeCount();
+    await getIt<TbStorage>().deleteItem(_pushRegisteredKey);
+  }
+
+  /// Cleans up the push registration after a session that ended without an
+  /// explicit logout (e.g. the refresh token expired while the app was
+  /// closed, #304). The JWT is already invalid at this point, so the
+  /// server-side mobile session usually can't be removed here; deleting the
+  /// local FCM token makes further pushes bounce, and the platform purges
+  /// the session on the next delivery attempt.
+  Future<void> handleSessionExpired() async {
+    final registered =
+        await getIt<TbStorage>().getItem(_pushRegisteredKey) as String?;
+    if (registered != 'true') {
+      return;
+    }
+
+    _log.debug('NotificationService::handleSessionExpired()');
+    try {
+      await logout();
+    } catch (e) {
+      _log.debug('NotificationService::handleSessionExpired() failed: $e');
+    }
   }
 
   Future<void> _configFirebaseMessaging() async {
@@ -198,6 +230,8 @@ class NotificationService {
           if (fcmToken != null) {
             await _saveToken(fcmToken);
           }
+        } else {
+          await _markPushRegistered();
         }
       } else {
         await _saveToken(fcmToken);
@@ -212,6 +246,11 @@ class NotificationService {
         (b) => b..fcmTokenTimestamp = DateTime.now().millisecondsSinceEpoch,
       ),
     );
+    await _markPushRegistered();
+  }
+
+  Future<void> _markPushRegistered() {
+    return getIt<TbStorage>().setItem(_pushRegisteredKey, 'true');
   }
 
   Future<void> showNotification(RemoteMessage message) async {

--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -11,30 +11,48 @@ import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/modules/notification/service/i_notifications_local_service.dart';
 import 'package:thingsboard_app/modules/notification/service/notifications_local_service.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
+import 'package:thingsboard_app/utils/services/local_database/i_local_database_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 import 'package:thingsboard_app/utils/utils.dart';
 
 class NotificationService {
-  static const _pushRegisteredKey = 'push_notifications_registered';
+  NotificationService({
+    FirebaseMessaging? messaging,
+    FlutterLocalNotificationsPlugin? localNotificationsPlugin,
+    INotificationsLocalService? localService,
+  }) : _messagingOverride = messaging,
+       flutterLocalNotificationsPlugin =
+           localNotificationsPlugin ?? FlutterLocalNotificationsPlugin(),
+       _localService = localService ?? NotificationsLocalService();
 
-  static FirebaseMessaging _messaging = FirebaseMessaging.instance;
+  final FirebaseMessaging? _messagingOverride;
   late NotificationDetails _notificationDetails;
   final TbLogger _log = getIt();
   final ThingsboardClient _tbClient = getIt<ITbClientService>().client;
-  final INotificationsLocalService _localService = NotificationsLocalService();
+  final ILocalDatabaseService _localDatabase = getIt();
+  final INotificationsLocalService _localService;
   StreamSubscription? _foregroundMessageSubscription;
   StreamSubscription? _onMessageOpenedAppSubscription;
   StreamSubscription? _onTokenRefreshSubscription;
 
   String? _fcmToken;
 
-  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin =
-      FlutterLocalNotificationsPlugin();
+  final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
+
+  FirebaseMessaging get _messaging =>
+      _messagingOverride ?? FirebaseMessaging.instance;
+
+  bool get _isFirebaseConfigured => getIt<IFirebaseService>().apps.isNotEmpty;
 
   Future<void> init() async {
+    if (!_isFirebaseConfigured) {
+      return;
+    }
+
     _log.debug('NotificationService::init()');
 
-    final message = await FirebaseMessaging.instance.getInitialMessage();
+    final message = await _messaging.getInitialMessage();
     if (message != null) {
       NotificationService.handleClickOnNotification(message.data);
     }
@@ -52,20 +70,32 @@ class NotificationService {
         settings.authorizationStatus == AuthorizationStatus.provisional) {
       await _getAndSaveToken();
 
-      _onTokenRefreshSubscription = FirebaseMessaging.instance.onTokenRefresh
-          .listen((token) {
-            if (_fcmToken != null) {
-              _tbClient
-                  .getUserControllerApi()
-                  .removeMobileSession(xMobileToken: _fcmToken!)
-                  .then((_) {
-                    _fcmToken = token;
-                    if (_fcmToken != null) {
-                      _saveToken(_fcmToken!);
-                    }
-                  });
-            }
-          });
+      _onTokenRefreshSubscription = _messaging.onTokenRefresh.listen((
+        token,
+      ) async {
+        if (_fcmToken == null) {
+          return;
+        }
+        final previousToken = _fcmToken!;
+        _fcmToken = token;
+        try {
+          await _tbClient.getUserControllerApi().removeMobileSession(
+            xMobileToken: previousToken,
+          );
+        } catch (e) {
+          _log.warn(
+            'NotificationService: failed to remove the mobile session of '
+            'the previous FCM token: $e',
+          );
+        }
+        try {
+          await _saveToken(token);
+        } catch (e) {
+          _log.warn(
+            'NotificationService: failed to save the refreshed FCM token: $e',
+          );
+        }
+      });
 
       await _initFlutterLocalNotificationsPlugin();
       await _configFirebaseMessaging();
@@ -75,9 +105,7 @@ class NotificationService {
   }
 
   Future<void> updateNotificationsCount() async {
-    final localService = NotificationsLocalService();
-
-    await localService.updateNotificationsCount(
+    await _localService.updateNotificationsCount(
       await _getNotificationsCountRemote(),
     );
   }
@@ -95,11 +123,13 @@ class NotificationService {
   }
 
   Future<void> logout() async {
-    getIt<TbLogger>().debug('NotificationService::logout()');
+    if (!_isFirebaseConfigured) {
+      return;
+    }
+
+    _log.debug('NotificationService::logout()');
     if (_fcmToken != null) {
-      getIt<TbLogger>().debug(
-        'NotificationService::logout() removeMobileSession',
-      );
+      _log.debug('NotificationService::logout() removeMobileSession');
       try {
         await _tbClient.getUserControllerApi().removeMobileSession(
           xMobileToken: _fcmToken!,
@@ -107,41 +137,53 @@ class NotificationService {
       } catch (e) {
         // Best effort: the session may already be invalid (e.g. expired JWT).
         // Deleting the local FCM token below still stops the notifications.
-        getIt<TbLogger>().debug(
+        _log.warn(
           'NotificationService::logout() removeMobileSession failed: $e',
         );
       }
     }
 
+    await _cleanupPushRegistration();
+  }
+
+  /// Cleans up a stale push registration left by a session that ended
+  /// without an explicit logout (e.g. the refresh token expired while the
+  /// app was closed, #304). The JWT is already invalid at this point, so the
+  /// server-side mobile session usually can't be removed here; deleting the
+  /// local FCM token makes further pushes bounce, and the platform purges
+  /// the session on the next delivery attempt.
+  ///
+  /// Idempotent and safe to call whenever the client is unauthenticated.
+  Future<void> cleanUpStalePushRegistration() async {
+    if (!_isFirebaseConfigured) {
+      return;
+    }
+    if (!await _localDatabase.isPushRegistered()) {
+      return;
+    }
+
+    _log.debug('NotificationService::cleanUpStalePushRegistration()');
+    try {
+      await _cleanupPushRegistration();
+    } catch (e) {
+      // The registration flag is deleted last, so an interrupted cleanup
+      // (e.g. no network) is retried on the next launch.
+      _log.warn(
+        'NotificationService::cleanUpStalePushRegistration() failed: $e',
+      );
+    }
+  }
+
+  Future<void> _cleanupPushRegistration() async {
     await _foregroundMessageSubscription?.cancel();
     await _onMessageOpenedAppSubscription?.cancel();
     await _onTokenRefreshSubscription?.cancel();
     await _messaging.deleteToken();
+    _fcmToken = null;
     await _messaging.setAutoInitEnabled(false);
     await flutterLocalNotificationsPlugin.cancelAll();
     await _localService.clearNotificationBadgeCount();
-    await getIt<TbStorage>().deleteItem(_pushRegisteredKey);
-  }
-
-  /// Cleans up the push registration after a session that ended without an
-  /// explicit logout (e.g. the refresh token expired while the app was
-  /// closed, #304). The JWT is already invalid at this point, so the
-  /// server-side mobile session usually can't be removed here; deleting the
-  /// local FCM token makes further pushes bounce, and the platform purges
-  /// the session on the next delivery attempt.
-  Future<void> handleSessionExpired() async {
-    final registered =
-        await getIt<TbStorage>().getItem(_pushRegisteredKey) as String?;
-    if (registered != 'true') {
-      return;
-    }
-
-    _log.debug('NotificationService::handleSessionExpired()');
-    try {
-      await logout();
-    } catch (e) {
-      _log.debug('NotificationService::handleSessionExpired() failed: $e');
-    }
+    await _localDatabase.clearPushRegistered();
   }
 
   Future<void> _configFirebaseMessaging() async {
@@ -193,7 +235,6 @@ class NotificationService {
   }
 
   Future<NotificationSettings> _requestPermission() async {
-    _messaging = FirebaseMessaging.instance;
     final result = await _messaging.requestPermission(provisional: true);
 
     if (result.authorizationStatus == AuthorizationStatus.denied) {
@@ -205,7 +246,15 @@ class NotificationService {
 
   Future<String?> _resetToken(String? token) async {
     if (token != null) {
-      _tbClient.getUserControllerApi().removeMobileSession(xMobileToken: token);
+      try {
+        await _tbClient.getUserControllerApi().removeMobileSession(
+          xMobileToken: token,
+        );
+      } catch (e) {
+        _log.warn(
+          'NotificationService::_resetToken() removeMobileSession failed: $e',
+        );
+      }
     }
 
     await _messaging.deleteToken();
@@ -216,26 +265,30 @@ class NotificationService {
     String? fcmToken = await getToken();
     _log.debug('FCM token: $fcmToken');
 
-    if (fcmToken != null) {
-      final mobileInfo =
-          (await _tbClient.getUserControllerApi().getMobileSession(
-            xMobileToken: fcmToken,
-          )).data;
-      if (mobileInfo != null) {
-        final int timeAfterCreatedToken =
-            DateTime.now().millisecondsSinceEpoch -
-            (mobileInfo.fcmTokenTimestamp ?? 0);
-        if (timeAfterCreatedToken > const Duration(days: 30).inMilliseconds) {
-          fcmToken = await _resetToken(fcmToken);
-          if (fcmToken != null) {
-            await _saveToken(fcmToken);
-          }
-        } else {
-          await _markPushRegistered();
+    if (fcmToken == null) {
+      return;
+    }
+
+    final mobileInfo =
+        (await _tbClient.getUserControllerApi().getMobileSession(
+          xMobileToken: fcmToken,
+        )).data;
+    if (mobileInfo == null) {
+      await _saveToken(fcmToken);
+    } else {
+      final int timeAfterCreatedToken =
+          DateTime.now().millisecondsSinceEpoch -
+          (mobileInfo.fcmTokenTimestamp ?? 0);
+      if (timeAfterCreatedToken > const Duration(days: 30).inMilliseconds) {
+        fcmToken = await _resetToken(fcmToken);
+        if (fcmToken != null) {
+          await _saveToken(fcmToken);
         }
-      } else {
-        await _saveToken(fcmToken);
       }
+    }
+
+    if (fcmToken != null) {
+      await _localDatabase.setPushRegistered();
     }
   }
 
@@ -246,11 +299,7 @@ class NotificationService {
         (b) => b..fcmTokenTimestamp = DateTime.now().millisecondsSinceEpoch,
       ),
     );
-    await _markPushRegistered();
-  }
-
-  Future<void> _markPushRegistered() {
-    return getIt<TbStorage>().setItem(_pushRegisteredKey, 'true');
+    await _localDatabase.setPushRegistered();
   }
 
   Future<void> showNotification(RemoteMessage message) async {

--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -21,12 +21,12 @@ class NotificationService {
     FirebaseMessaging? messaging,
     FlutterLocalNotificationsPlugin? localNotificationsPlugin,
     INotificationsLocalService? localService,
-  }) : _messagingOverride = messaging,
+  }) : _injectedMessaging = messaging,
        flutterLocalNotificationsPlugin =
            localNotificationsPlugin ?? FlutterLocalNotificationsPlugin(),
        _localService = localService ?? NotificationsLocalService();
 
-  final FirebaseMessaging? _messagingOverride;
+  final FirebaseMessaging? _injectedMessaging;
   late NotificationDetails _notificationDetails;
   final TbLogger _log = getIt();
   final ThingsboardClient _tbClient = getIt<ITbClientService>().client;
@@ -35,13 +35,17 @@ class NotificationService {
   StreamSubscription? _foregroundMessageSubscription;
   StreamSubscription? _onMessageOpenedAppSubscription;
   StreamSubscription? _onTokenRefreshSubscription;
+  Future<void>? _staleCleanup;
 
   String? _fcmToken;
 
   final FlutterLocalNotificationsPlugin flutterLocalNotificationsPlugin;
 
+  /// Resolved lazily: `FirebaseMessaging.instance` needs an initialized
+  /// Firebase app, and the locator constructs this service before `main()`
+  /// initializes Firebase.
   FirebaseMessaging get _messaging =>
-      _messagingOverride ?? FirebaseMessaging.instance;
+      _injectedMessaging ?? FirebaseMessaging.instance;
 
   bool get _isFirebaseConfigured => getIt<IFirebaseService>().apps.isNotEmpty;
 
@@ -49,6 +53,9 @@ class NotificationService {
     if (!_isFirebaseConfigured) {
       return;
     }
+    // A stale cleanup started while unauthenticated may still be deleting the
+    // FCM token; registering concurrently would delete the token just saved.
+    await _staleCleanup;
 
     _log.debug('NotificationService::init()');
 
@@ -62,7 +69,7 @@ class NotificationService {
           NotificationService.handleClickOnNotification(message.data);
         });
 
-    final settings = await _requestPermission();
+    final settings = await _messaging.requestPermission(provisional: true);
     _log.debug(
       'Notification authorizationStatus: ${settings.authorizationStatus}',
     );
@@ -73,20 +80,19 @@ class NotificationService {
       _onTokenRefreshSubscription = _messaging.onTokenRefresh.listen((
         token,
       ) async {
-        if (_fcmToken == null) {
-          return;
-        }
-        final previousToken = _fcmToken!;
+        final previousToken = _fcmToken;
         _fcmToken = token;
-        try {
-          await _tbClient.getUserControllerApi().removeMobileSession(
-            xMobileToken: previousToken,
-          );
-        } catch (e) {
-          _log.warn(
-            'NotificationService: failed to remove the mobile session of '
-            'the previous FCM token: $e',
-          );
+        if (previousToken != null) {
+          try {
+            await _tbClient.getUserControllerApi().removeMobileSession(
+              xMobileToken: previousToken,
+            );
+          } catch (e) {
+            _log.warn(
+              'NotificationService: failed to remove the mobile session of '
+              'the previous FCM token: $e',
+            );
+          }
         }
         try {
           await _saveToken(token);
@@ -143,7 +149,7 @@ class NotificationService {
       }
     }
 
-    await _cleanupPushRegistration();
+    await _tearDownLocalPushState();
   }
 
   /// Cleans up a stale push registration left by a session that ended
@@ -154,36 +160,42 @@ class NotificationService {
   /// the session on the next delivery attempt.
   ///
   /// Idempotent and safe to call whenever the client is unauthenticated.
-  Future<void> cleanUpStalePushRegistration() async {
+  /// Concurrent calls share a single run, and [init] waits for it to finish.
+  Future<void> cleanUpStalePushRegistration() {
     if (!_isFirebaseConfigured) {
-      return;
+      return Future.value();
     }
+    return _staleCleanup ??= _tearDownIfRegistered().whenComplete(
+      () => _staleCleanup = null,
+    );
+  }
+
+  Future<void> _tearDownIfRegistered() async {
     if (!await _localDatabase.isPushRegistered()) {
       return;
     }
-
     _log.debug('NotificationService::cleanUpStalePushRegistration()');
-    try {
-      await _cleanupPushRegistration();
-    } catch (e) {
-      // The registration flag is deleted last, so an interrupted cleanup
-      // (e.g. no network) is retried on the next launch.
-      _log.warn(
-        'NotificationService::cleanUpStalePushRegistration() failed: $e',
-      );
-    }
+    await _tearDownLocalPushState();
   }
 
-  Future<void> _cleanupPushRegistration() async {
-    await _foregroundMessageSubscription?.cancel();
-    await _onMessageOpenedAppSubscription?.cancel();
-    await _onTokenRefreshSubscription?.cancel();
-    await _messaging.deleteToken();
-    _fcmToken = null;
-    await _messaging.setAutoInitEnabled(false);
-    await flutterLocalNotificationsPlugin.cancelAll();
-    await _localService.clearNotificationBadgeCount();
-    await _localDatabase.clearPushRegistered();
+  /// Deleting the FCM token is what stops delivery; the rest drops the local
+  /// push state. Failures are swallowed so a logout still completes offline:
+  /// the registration flag is cleared last, so an interrupted teardown is
+  /// retried by [cleanUpStalePushRegistration] on the next launch.
+  Future<void> _tearDownLocalPushState() async {
+    try {
+      await _foregroundMessageSubscription?.cancel();
+      await _onMessageOpenedAppSubscription?.cancel();
+      await _onTokenRefreshSubscription?.cancel();
+      await _messaging.deleteToken();
+      _fcmToken = null;
+      await _messaging.setAutoInitEnabled(false);
+      await flutterLocalNotificationsPlugin.cancelAll();
+      await _localService.clearNotificationBadgeCount();
+      await _localDatabase.clearPushRegistered();
+    } catch (e) {
+      _log.warn('NotificationService: push teardown failed: $e');
+    }
   }
 
   Future<void> _configFirebaseMessaging() async {
@@ -234,16 +246,6 @@ class NotificationService {
     );
   }
 
-  Future<NotificationSettings> _requestPermission() async {
-    final result = await _messaging.requestPermission(provisional: true);
-
-    if (result.authorizationStatus == AuthorizationStatus.denied) {
-      return result;
-    }
-
-    return result;
-  }
-
   Future<String?> _resetToken(String? token) async {
     if (token != null) {
       try {
@@ -262,7 +264,7 @@ class NotificationService {
   }
 
   Future<void> _getAndSaveToken() async {
-    String? fcmToken = await getToken();
+    final fcmToken = await getToken();
     _log.debug('FCM token: $fcmToken');
 
     if (fcmToken == null) {
@@ -275,21 +277,21 @@ class NotificationService {
         )).data;
     if (mobileInfo == null) {
       await _saveToken(fcmToken);
-    } else {
-      final int timeAfterCreatedToken =
-          DateTime.now().millisecondsSinceEpoch -
-          (mobileInfo.fcmTokenTimestamp ?? 0);
-      if (timeAfterCreatedToken > const Duration(days: 30).inMilliseconds) {
-        fcmToken = await _resetToken(fcmToken);
-        if (fcmToken != null) {
-          await _saveToken(fcmToken);
-        }
-      }
+      return;
     }
 
-    if (fcmToken != null) {
-      await _localDatabase.setPushRegistered();
+    final tokenAge =
+        DateTime.now().millisecondsSinceEpoch -
+        (mobileInfo.fcmTokenTimestamp ?? 0);
+    if (tokenAge > const Duration(days: 30).inMilliseconds) {
+      final freshToken = await _resetToken(fcmToken);
+      if (freshToken != null) {
+        await _saveToken(freshToken);
+      }
+      return;
     }
+
+    await _localDatabase.setPushRegistered();
   }
 
   Future<void> _saveToken(String token) async {

--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -179,6 +179,9 @@ class NotificationService {
 
   Future<void> _tearDownIfRegistered() async {
     try {
+      // The flag keeps this a no-op on devices that never registered, so a
+      // fresh install sitting on the login screen never calls into FCM:
+      // deleteToken() without a token can mint one just to delete it.
       if (!await _localDatabase.isPushRegistered()) {
         return;
       }

--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -181,7 +181,7 @@ class NotificationService {
     try {
       // The flag keeps this a no-op on devices that never registered, so a
       // fresh install sitting on the login screen never calls into FCM:
-      // deleteToken() without a token can mint one just to delete it.
+      // deleteToken() is an unconditional platform round trip either way.
       if (!await _localDatabase.isPushRegistered()) {
         return;
       }
@@ -195,7 +195,10 @@ class NotificationService {
   /// Deleting the FCM token is what stops delivery; the rest drops the local
   /// push state. Failures are swallowed so a logout still completes offline:
   /// the registration flag is cleared last, so an interrupted teardown is
-  /// retried by [cleanUpStalePushRegistration] on the next launch.
+  /// retried by [cleanUpStalePushRegistration] on the next launch. On iOS
+  /// `deleteToken()` throws `apns-token-not-set` until the APNS token the
+  /// plugin requests at launch has arrived (e.g. an offline launch); that is
+  /// one such interruption.
   Future<void> _tearDownLocalPushState() async {
     try {
       await _foregroundMessageSubscription?.cancel();

--- a/lib/utils/services/notification_service.dart
+++ b/lib/utils/services/notification_service.dart
@@ -178,21 +178,15 @@ class NotificationService {
   }
 
   Future<void> _tearDownIfRegistered() async {
-    final bool registered;
     try {
-      registered = await _localDatabase.isPushRegistered();
+      if (!await _localDatabase.isPushRegistered()) {
+        return;
+      }
+      _log.debug('NotificationService::_tearDownIfRegistered()');
+      await _tearDownLocalPushState();
     } catch (e) {
-      _log.warn(
-        'NotificationService::_tearDownIfRegistered() failed to read the '
-        'registration flag: $e',
-      );
-      return;
+      _log.warn('NotificationService::_tearDownIfRegistered() failed: $e');
     }
-    if (!registered) {
-      return;
-    }
-    _log.debug('NotificationService::_tearDownIfRegistered()');
-    await _tearDownLocalPushState();
   }
 
   /// Deleting the FCM token is what stops delivery; the rest drops the local

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -490,7 +490,7 @@ packages:
     source: hosted
     version: "0.4.1"
   dio:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: dio
       sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -490,7 +490,7 @@ packages:
     source: hosted
     version: "0.4.1"
   dio:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: dio
       sha256: d90ee57923d1828ac14e492ca49440f65477f4bb1263575900be731a3dac66a9

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -94,6 +94,7 @@ dependencies:
   barcode: ^2.2.9
   riverpod_annotation: ^2.6.1
   path_provider: ^2.1.5
+  dio: ^5.7.0
 dev_dependencies:
   integration_test:
     sdk: flutter
@@ -101,7 +102,6 @@ dev_dependencies:
     sdk: flutter
   flutter_launcher_icons: ^0.14.4
   mocktail: ^1.0.3
-  dio: ^5.7.0
   bloc_test: ^9.1.7
   flutter_lints: ^2.0.3
   build_runner: ^2.4.9

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -101,6 +101,7 @@ dev_dependencies:
     sdk: flutter
   flutter_launcher_icons: ^0.14.4
   mocktail: ^1.0.3
+  dio: ^5.7.0
   bloc_test: ^9.1.7
   flutter_lints: ^2.0.3
   build_runner: ^2.4.9

--- a/test/helpers/test_dependencies.dart
+++ b/test/helpers/test_dependencies.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:thingsboard_app/core/logger/tb_logger.dart';
 import 'package:thingsboard_app/locator.dart';
@@ -18,26 +19,19 @@ class MockFirebaseService extends Mock implements IFirebaseService {}
 
 /// Registers the locator dependencies that services resolve in their field
 /// initializers, so a test can construct them without booting the real app.
-/// Pass overrides for the collaborators the test stubs or asserts on.
+/// The locator is reset automatically when the current test finishes.
 void registerTestDependencies({
-  ThingsboardClient? tbClient,
-  ILocalDatabaseService? localDatabase,
-  IFirebaseService? firebaseService,
+  required ThingsboardClient tbClient,
+  required ILocalDatabaseService localDatabase,
+  required IFirebaseService firebaseService,
 }) {
   final clientService = MockTbClientService();
-  when(
-    () => clientService.client,
-  ).thenReturn(tbClient ?? MockThingsboardClient());
+  when(() => clientService.client).thenReturn(tbClient);
 
   getIt
     ..registerLazySingleton<TbLogger>(() => MockTbLogger())
     ..registerLazySingleton<ITbClientService>(() => clientService)
-    ..registerLazySingleton<ILocalDatabaseService>(
-      () => localDatabase ?? MockLocalDatabaseService(),
-    )
-    ..registerLazySingleton<IFirebaseService>(
-      () => firebaseService ?? MockFirebaseService(),
-    );
+    ..registerLazySingleton<ILocalDatabaseService>(() => localDatabase)
+    ..registerLazySingleton<IFirebaseService>(() => firebaseService);
+  addTearDown(getIt.reset);
 }
-
-Future<void> resetTestDependencies() => getIt.reset();

--- a/test/helpers/test_dependencies.dart
+++ b/test/helpers/test_dependencies.dart
@@ -1,0 +1,43 @@
+import 'package:mocktail/mocktail.dart';
+import 'package:thingsboard_app/core/logger/tb_logger.dart';
+import 'package:thingsboard_app/locator.dart';
+import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
+import 'package:thingsboard_app/utils/services/local_database/i_local_database_service.dart';
+import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
+
+class MockTbLogger extends Mock implements TbLogger {}
+
+class MockTbClientService extends Mock implements ITbClientService {}
+
+class MockThingsboardClient extends Mock implements ThingsboardClient {}
+
+class MockLocalDatabaseService extends Mock implements ILocalDatabaseService {}
+
+class MockFirebaseService extends Mock implements IFirebaseService {}
+
+/// Registers the locator dependencies that services resolve in their field
+/// initializers, so a test can construct them without booting the real app.
+/// Pass overrides for the collaborators the test stubs or asserts on.
+void registerTestDependencies({
+  ThingsboardClient? tbClient,
+  ILocalDatabaseService? localDatabase,
+  IFirebaseService? firebaseService,
+}) {
+  final clientService = MockTbClientService();
+  when(
+    () => clientService.client,
+  ).thenReturn(tbClient ?? MockThingsboardClient());
+
+  getIt
+    ..registerLazySingleton<TbLogger>(() => MockTbLogger())
+    ..registerLazySingleton<ITbClientService>(() => clientService)
+    ..registerLazySingleton<ILocalDatabaseService>(
+      () => localDatabase ?? MockLocalDatabaseService(),
+    )
+    ..registerLazySingleton<IFirebaseService>(
+      () => firebaseService ?? MockFirebaseService(),
+    );
+}
+
+Future<void> resetTestDependencies() => getIt.reset();

--- a/test/utils/services/local_database_service_test.dart
+++ b/test/utils/services/local_database_service_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/local_database/local_database_service.dart';
+
+import '../../helpers/test_dependencies.dart';
+
+class MockTbStorage extends Mock implements TbStorage {}
+
+void main() {
+  late MockTbStorage storage;
+  late LocalDatabaseService service;
+
+  setUp(() {
+    storage = MockTbStorage();
+    service = LocalDatabaseService(storage: storage, logger: MockTbLogger());
+  });
+
+  // The literal key is asserted on purpose: it is the persisted contract, so
+  // renaming the constant must fail these tests rather than drift silently.
+  group('push registration flag', () {
+    test('setPushRegistered stores the flag under the persisted key', () async {
+      when(() => storage.setItem(any(), any())).thenAnswer((_) async {});
+
+      await service.setPushRegistered();
+
+      verify(
+        () => storage.setItem('push_notifications_registered', true),
+      ).called(1);
+    });
+
+    test('isPushRegistered checks the persisted key', () async {
+      when(() => storage.containsKey(any())).thenAnswer((_) async => true);
+
+      expect(await service.isPushRegistered(), isTrue);
+
+      verify(
+        () => storage.containsKey('push_notifications_registered'),
+      ).called(1);
+    });
+
+    test('clearPushRegistered deletes the persisted key', () async {
+      when(() => storage.deleteItem(any())).thenAnswer((_) async {});
+
+      await service.clearPushRegistered();
+
+      verify(
+        () => storage.deleteItem('push_notifications_registered'),
+      ).called(1);
+    });
+  });
+}

--- a/test/utils/services/local_database_service_test.dart
+++ b/test/utils/services/local_database_service_test.dart
@@ -25,18 +25,22 @@ void main() {
       await service.setPushRegistered();
 
       verify(
-        () => storage.setItem('push_notifications_registered', true),
+        () => storage.setItem('pushNotificationsRegistered', true),
       ).called(1);
     });
 
-    test('isPushRegistered checks the persisted key', () async {
-      when(() => storage.containsKey(any())).thenAnswer((_) async => true);
+    test('isPushRegistered reads the stored flag', () async {
+      when(() => storage.getItem(any())).thenAnswer((_) async => true);
 
       expect(await service.isPushRegistered(), isTrue);
 
-      verify(
-        () => storage.containsKey('push_notifications_registered'),
-      ).called(1);
+      verify(() => storage.getItem('pushNotificationsRegistered')).called(1);
+    });
+
+    test('isPushRegistered is false when the flag was never stored', () async {
+      when(() => storage.getItem(any())).thenAnswer((_) async => null);
+
+      expect(await service.isPushRegistered(), isFalse);
     });
 
     test('clearPushRegistered deletes the persisted key', () async {
@@ -44,9 +48,7 @@ void main() {
 
       await service.clearPushRegistered();
 
-      verify(
-        () => storage.deleteItem('push_notifications_registered'),
-      ).called(1);
+      verify(() => storage.deleteItem('pushNotificationsRegistered')).called(1);
     });
   });
 }

--- a/test/utils/services/notification_service_test.dart
+++ b/test/utils/services/notification_service_test.dart
@@ -92,6 +92,21 @@ void main() {
     ),
   ).called(1);
 
+  void verifyNoSessionSaved() => verifyNever(
+    () => userApi.saveMobileSession(
+      xMobileToken: any(named: 'xMobileToken'),
+      mobileSessionInfo: any(named: 'mobileSessionInfo'),
+    ),
+  );
+
+  void verifyNoSessionRemoval() => verifyNever(
+    () => userApi.removeMobileSession(xMobileToken: any(named: 'xMobileToken')),
+  );
+
+  void stubPushRegistered() => when(
+    () => localDatabase.isPushRegistered(),
+  ).thenAnswer((_) async => true);
+
   setUp(() {
     messaging = MockFirebaseMessaging();
     localNotificationsPlugin = MockFlutterLocalNotificationsPlugin();
@@ -175,13 +190,22 @@ void main() {
       verifyNever(() => localDatabase.setPushRegistered());
     });
 
-    test('registers the device and marks push as registered when the '
-        'server has no session for the token', () async {
-      await buildService().init();
+    for (final status in [
+      AuthorizationStatus.authorized,
+      AuthorizationStatus.provisional,
+    ]) {
+      test('registers the device and marks push as registered under '
+          '$status when the server has no session for the token', () async {
+        when(
+          () => messaging.requestPermission(provisional: true),
+        ).thenAnswer((_) async => permission(status));
 
-      verifyMobileSessionSaved(fcmToken);
-      verify(() => localDatabase.setPushRegistered()).called(1);
-    });
+        await buildService().init();
+
+        verifyMobileSessionSaved(fcmToken);
+        verify(() => localDatabase.setPushRegistered()).called(1);
+      });
+    }
 
     test('marks push as registered without re-saving a fresh '
         'server-side session', () async {
@@ -189,12 +213,7 @@ void main() {
 
       await buildService().init();
 
-      verifyNever(
-        () => userApi.saveMobileSession(
-          xMobileToken: any(named: 'xMobileToken'),
-          mobileSessionInfo: any(named: 'mobileSessionInfo'),
-        ),
-      );
+      verifyNoSessionSaved();
       verify(() => localDatabase.setPushRegistered()).called(1);
     });
 
@@ -217,6 +236,21 @@ void main() {
         ),
       ]);
       verify(() => localDatabase.setPushRegistered()).called(1);
+    });
+
+    test('leaves push unregistered when the rotation cannot obtain a fresh '
+        'token', () async {
+      stubMobileSession(sessionRegistered(const Duration(days: 31)));
+      final tokens = <String?>[fcmToken, null];
+      when(
+        () => messaging.getToken(),
+      ).thenAnswer((_) async => tokens.removeAt(0));
+
+      await buildService().init();
+
+      verify(() => messaging.deleteToken()).called(1);
+      verifyNoSessionSaved();
+      verifyNever(() => localDatabase.setPushRegistered());
     });
 
     test('does not mark push as registered when no FCM token is '
@@ -246,9 +280,7 @@ void main() {
 
     test('waits for a pending stale cleanup, so the token it registers '
         'is not the one being deleted', () async {
-      when(
-        () => localDatabase.isPushRegistered(),
-      ).thenAnswer((_) async => true);
+      stubPushRegistered();
       final deleteToken = Completer<void>();
       when(() => messaging.deleteToken()).thenAnswer((_) => deleteToken.future);
       final service = buildService();
@@ -293,11 +325,7 @@ void main() {
       tokenRefreshes.add(refreshedToken);
       await pumpEventQueue();
 
-      verifyNever(
-        () => userApi.removeMobileSession(
-          xMobileToken: any(named: 'xMobileToken'),
-        ),
-      );
+      verifyNoSessionRemoval();
       verifyMobileSessionSaved(refreshedToken);
       verify(() => localDatabase.setPushRegistered()).called(1);
     });
@@ -315,6 +343,26 @@ void main() {
       await pumpEventQueue();
 
       verifyMobileSessionSaved(refreshedToken);
+    });
+
+    test('keeps listening when saving the refreshed token fails', () async {
+      when(
+        () => userApi.saveMobileSession(
+          xMobileToken: refreshedToken,
+          mobileSessionInfo: any(named: 'mobileSessionInfo'),
+        ),
+      ).thenThrow(Exception('500'));
+      await buildService().init();
+
+      tokenRefreshes.add(refreshedToken);
+      await pumpEventQueue();
+      tokenRefreshes.add('second-refreshed-token');
+      await pumpEventQueue();
+
+      verify(
+        () => userApi.removeMobileSession(xMobileToken: refreshedToken),
+      ).called(1);
+      verifyMobileSessionSaved('second-refreshed-token');
     });
   });
 
@@ -341,9 +389,7 @@ void main() {
 
     test('cleans up the local registration when the session expired '
         'after a login', () async {
-      when(
-        () => localDatabase.isPushRegistered(),
-      ).thenAnswer((_) async => true);
+      stubPushRegistered();
 
       await buildService().cleanUpStalePushRegistration();
 
@@ -352,18 +398,12 @@ void main() {
       verify(() => localNotificationsPlugin.cancelAll()).called(1);
       verify(() => localService.clearNotificationBadgeCount()).called(1);
       verify(() => localDatabase.clearPushRegistered()).called(1);
-      verifyNever(
-        () => userApi.removeMobileSession(
-          xMobileToken: any(named: 'xMobileToken'),
-        ),
-      );
+      verifyNoSessionRemoval();
     });
 
     test('keeps the registration flag when the cleanup is interrupted, '
         'so it is retried on the next launch', () async {
-      when(
-        () => localDatabase.isPushRegistered(),
-      ).thenAnswer((_) async => true);
+      stubPushRegistered();
       when(() => messaging.deleteToken()).thenThrow(Exception('no network'));
 
       await buildService().cleanUpStalePushRegistration();
@@ -372,9 +412,7 @@ void main() {
     });
 
     test('runs a single teardown for concurrent calls', () async {
-      when(
-        () => localDatabase.isPushRegistered(),
-      ).thenAnswer((_) async => true);
+      stubPushRegistered();
       final service = buildService();
 
       await Future.wait([
@@ -383,6 +421,40 @@ void main() {
       ]);
 
       verify(() => messaging.deleteToken()).called(1);
+    });
+
+    test('retries the teardown on the next call after an interrupted one '
+        'and clears the flag once it succeeds', () async {
+      stubPushRegistered();
+      var deleteAttempts = 0;
+      when(() => messaging.deleteToken()).thenAnswer((_) async {
+        if (deleteAttempts++ == 0) {
+          throw Exception('no network');
+        }
+      });
+      final service = buildService();
+
+      await service.cleanUpStalePushRegistration();
+      verifyNever(() => localDatabase.clearPushRegistered());
+
+      await service.cleanUpStalePushRegistration();
+
+      verify(() => messaging.deleteToken()).called(2);
+      verify(() => localDatabase.clearPushRegistered()).called(1);
+    });
+
+    test('completes when the registration flag cannot be read, so a later '
+        'init() still registers', () async {
+      when(
+        () => localDatabase.isPushRegistered(),
+      ).thenThrow(Exception('corrupt box'));
+      final service = buildService();
+
+      await expectLater(service.cleanUpStalePushRegistration(), completes);
+      await service.init();
+
+      verifyNever(() => messaging.deleteToken());
+      verify(() => localDatabase.setPushRegistered()).called(1);
     });
   });
 

--- a/test/utils/services/notification_service_test.dart
+++ b/test/utils/services/notification_service_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:thingsboard_app/core/logger/tb_logger.dart';
+import 'package:thingsboard_app/locator.dart';
+import 'package:thingsboard_app/thingsboard_client.dart';
+import 'package:thingsboard_app/utils/services/notification_service.dart';
+import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
+
+class MockTbStorage extends Mock implements TbStorage {}
+
+class MockTbClientService extends Mock implements ITbClientService {}
+
+class MockThingsboardClient extends Mock implements ThingsboardClient {}
+
+class TestableNotificationService extends NotificationService {
+  int logoutCalls = 0;
+
+  @override
+  Future<void> logout() async {
+    logoutCalls++;
+  }
+}
+
+void main() {
+  late MockTbStorage storage;
+
+  setUp(() {
+    storage = MockTbStorage();
+    final clientService = MockTbClientService();
+    when(() => clientService.client).thenReturn(MockThingsboardClient());
+
+    getIt
+      ..registerLazySingleton(() => TbLogger())
+      ..registerLazySingleton<TbStorage>(() => storage)
+      ..registerLazySingleton<ITbClientService>(() => clientService);
+  });
+
+  tearDown(() => getIt.reset());
+
+  group('NotificationService.handleSessionExpired', () {
+    test(
+      'does nothing when push notifications were never registered',
+      () async {
+        when(() => storage.getItem(any())).thenAnswer((_) async => null);
+        final service = TestableNotificationService();
+
+        await service.handleSessionExpired();
+
+        expect(service.logoutCalls, 0);
+      },
+    );
+
+    test(
+      'cleans up the registration when the session expired after a login',
+      () async {
+        when(() => storage.getItem(any())).thenAnswer((_) async => 'true');
+        final service = TestableNotificationService();
+
+        await service.handleSessionExpired();
+
+        expect(service.logoutCalls, 1);
+      },
+    );
+  });
+}

--- a/test/utils/services/notification_service_test.dart
+++ b/test/utils/services/notification_service_test.dart
@@ -1,65 +1,196 @@
+import 'package:dio/dio.dart';
+import 'package:firebase_messaging/firebase_messaging.dart';
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:thingsboard_app/core/logger/tb_logger.dart';
-import 'package:thingsboard_app/locator.dart';
+import 'package:thingsboard_app/modules/notification/service/i_notifications_local_service.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/utils/services/notification_service.dart';
-import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
 
-class MockTbStorage extends Mock implements TbStorage {}
+import '../../helpers/test_dependencies.dart';
 
-class MockTbClientService extends Mock implements ITbClientService {}
+class MockFirebaseMessaging extends Mock implements FirebaseMessaging {}
 
-class MockThingsboardClient extends Mock implements ThingsboardClient {}
+class MockFlutterLocalNotificationsPlugin extends Mock
+    implements FlutterLocalNotificationsPlugin {}
 
-class TestableNotificationService extends NotificationService {
-  int logoutCalls = 0;
+class MockNotificationsLocalService extends Mock
+    implements INotificationsLocalService {}
 
-  @override
-  Future<void> logout() async {
-    logoutCalls++;
-  }
-}
+class MockUserControllerApi extends Mock implements UserControllerApi {}
 
 void main() {
-  late MockTbStorage storage;
+  late MockFirebaseMessaging messaging;
+  late MockFlutterLocalNotificationsPlugin localNotificationsPlugin;
+  late MockNotificationsLocalService localService;
+  late MockLocalDatabaseService localDatabase;
+  late MockFirebaseService firebaseService;
+  late MockUserControllerApi userApi;
+
+  NotificationService buildService() => NotificationService(
+    messaging: messaging,
+    localNotificationsPlugin: localNotificationsPlugin,
+    localService: localService,
+  );
 
   setUp(() {
-    storage = MockTbStorage();
-    final clientService = MockTbClientService();
-    when(() => clientService.client).thenReturn(MockThingsboardClient());
+    messaging = MockFirebaseMessaging();
+    localNotificationsPlugin = MockFlutterLocalNotificationsPlugin();
+    localService = MockNotificationsLocalService();
+    localDatabase = MockLocalDatabaseService();
+    firebaseService = MockFirebaseService();
+    userApi = MockUserControllerApi();
 
-    getIt
-      ..registerLazySingleton(() => TbLogger())
-      ..registerLazySingleton<TbStorage>(() => storage)
-      ..registerLazySingleton<ITbClientService>(() => clientService);
+    final tbClient = MockThingsboardClient();
+    when(() => tbClient.getUserControllerApi()).thenReturn(userApi);
+    when(() => firebaseService.apps).thenReturn(['[DEFAULT]']);
+    when(() => messaging.deleteToken()).thenAnswer((_) async {});
+    when(() => messaging.setAutoInitEnabled(any())).thenAnswer((_) async {});
+    when(() => localNotificationsPlugin.cancelAll()).thenAnswer((_) async {});
+    when(
+      () => localService.clearNotificationBadgeCount(),
+    ).thenAnswer((_) async {});
+    when(() => localDatabase.clearPushRegistered()).thenAnswer((_) async {});
+
+    registerTestDependencies(
+      tbClient: tbClient,
+      localDatabase: localDatabase,
+      firebaseService: firebaseService,
+    );
   });
 
-  tearDown(() => getIt.reset());
+  tearDown(resetTestDependencies);
 
-  group('NotificationService.handleSessionExpired', () {
+  group('NotificationService.cleanUpStalePushRegistration', () {
+    test('skips entirely when Firebase is not configured', () async {
+      when(() => firebaseService.apps).thenReturn(const []);
+      final service = buildService();
+
+      await service.cleanUpStalePushRegistration();
+
+      verifyNever(() => localDatabase.isPushRegistered());
+      verifyNever(() => messaging.deleteToken());
+    });
+
     test(
       'does nothing when push notifications were never registered',
       () async {
-        when(() => storage.getItem(any())).thenAnswer((_) async => null);
-        final service = TestableNotificationService();
+        when(
+          () => localDatabase.isPushRegistered(),
+        ).thenAnswer((_) async => false);
+        final service = buildService();
 
-        await service.handleSessionExpired();
+        await service.cleanUpStalePushRegistration();
 
-        expect(service.logoutCalls, 0);
+        verify(() => localDatabase.isPushRegistered()).called(1);
+        verifyNever(() => messaging.deleteToken());
+        verifyNever(() => localDatabase.clearPushRegistered());
       },
     );
 
-    test(
-      'cleans up the registration when the session expired after a login',
-      () async {
-        when(() => storage.getItem(any())).thenAnswer((_) async => 'true');
-        final service = TestableNotificationService();
+    test('cleans up the local registration when the session expired '
+        'after a login', () async {
+      when(
+        () => localDatabase.isPushRegistered(),
+      ).thenAnswer((_) async => true);
+      final service = buildService();
 
-        await service.handleSessionExpired();
+      await service.cleanUpStalePushRegistration();
 
-        expect(service.logoutCalls, 1);
-      },
-    );
+      verify(() => messaging.deleteToken()).called(1);
+      verify(() => messaging.setAutoInitEnabled(false)).called(1);
+      verify(() => localNotificationsPlugin.cancelAll()).called(1);
+      verify(() => localService.clearNotificationBadgeCount()).called(1);
+      verify(() => localDatabase.clearPushRegistered()).called(1);
+      verifyNever(
+        () => userApi.removeMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+        ),
+      );
+    });
+
+    test('keeps the registration flag when the cleanup is interrupted, '
+        'so it is retried on the next launch', () async {
+      when(
+        () => localDatabase.isPushRegistered(),
+      ).thenAnswer((_) async => true);
+      when(() => messaging.deleteToken()).thenThrow(Exception('no network'));
+      final service = buildService();
+
+      await service.cleanUpStalePushRegistration();
+
+      verifyNever(() => localDatabase.clearPushRegistered());
+    });
+  });
+
+  group('NotificationService.logout', () {
+    Response<void> emptyResponse() =>
+        Response<void>(requestOptions: RequestOptions());
+
+    test('skips entirely when Firebase is not configured', () async {
+      when(() => firebaseService.apps).thenReturn(const []);
+      final service = buildService();
+
+      await service.logout();
+
+      verifyNever(() => messaging.deleteToken());
+    });
+
+    test('removes the mobile session and cleans up the local '
+        'registration', () async {
+      when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
+      when(
+        () => userApi.removeMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+        ),
+      ).thenAnswer((_) async => emptyResponse());
+      final service = buildService();
+      await service.getToken();
+
+      await service.logout();
+
+      verify(
+        () => userApi.removeMobileSession(xMobileToken: 'fcm-token'),
+      ).called(1);
+      verify(() => messaging.deleteToken()).called(1);
+      verify(() => localDatabase.clearPushRegistered()).called(1);
+    });
+
+    test('still cleans up when removeMobileSession fails '
+        '(e.g. the JWT already expired)', () async {
+      when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
+      when(
+        () => userApi.removeMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+        ),
+      ).thenThrow(Exception('401'));
+      final service = buildService();
+      await service.getToken();
+
+      await service.logout();
+
+      verify(() => messaging.deleteToken()).called(1);
+      verify(() => localDatabase.clearPushRegistered()).called(1);
+    });
+
+    test('does not reuse the deleted FCM token on a repeated logout', () async {
+      when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
+      when(
+        () => userApi.removeMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+        ),
+      ).thenAnswer((_) async => emptyResponse());
+      final service = buildService();
+      await service.getToken();
+
+      await service.logout();
+      await service.logout();
+
+      verify(
+        () => userApi.removeMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+        ),
+      ).called(1);
+    });
   });
 }

--- a/test/utils/services/notification_service_test.dart
+++ b/test/utils/services/notification_service_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:dio/dio.dart';
 import 'package:firebase_messaging/firebase_messaging.dart';
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
@@ -19,6 +21,38 @@ class MockNotificationsLocalService extends Mock
 
 class MockUserControllerApi extends Mock implements UserControllerApi {}
 
+class MockNotificationControllerApi extends Mock
+    implements NotificationControllerApi {}
+
+const fcmToken = 'fcm-token';
+const refreshedToken = 'refreshed-token';
+
+Response<T> response<T>([T? data]) =>
+    Response<T>(requestOptions: RequestOptions(), data: data);
+
+NotificationSettings permission(AuthorizationStatus status) =>
+    NotificationSettings(
+      authorizationStatus: status,
+      alert: AppleNotificationSetting.notSupported,
+      announcement: AppleNotificationSetting.notSupported,
+      badge: AppleNotificationSetting.notSupported,
+      carPlay: AppleNotificationSetting.notSupported,
+      criticalAlert: AppleNotificationSetting.notSupported,
+      lockScreen: AppleNotificationSetting.notSupported,
+      notificationCenter: AppleNotificationSetting.notSupported,
+      showPreviews: AppleShowPreviewSetting.notSupported,
+      sound: AppleNotificationSetting.notSupported,
+      timeSensitive: AppleNotificationSetting.notSupported,
+      providesAppNotificationSettings: AppleNotificationSetting.notSupported,
+    );
+
+MobileSessionInfo sessionRegistered(Duration ago) => MobileSessionInfo(
+  (b) =>
+      b
+        ..fcmTokenTimestamp =
+            DateTime.now().subtract(ago).millisecondsSinceEpoch,
+);
+
 void main() {
   late MockFirebaseMessaging messaging;
   late MockFlutterLocalNotificationsPlugin localNotificationsPlugin;
@@ -26,12 +60,37 @@ void main() {
   late MockLocalDatabaseService localDatabase;
   late MockFirebaseService firebaseService;
   late MockUserControllerApi userApi;
+  late StreamController<String> tokenRefreshes;
+
+  setUpAll(() {
+    registerFallbackValue(const InitializationSettings());
+    registerFallbackValue(MobileSessionInfo());
+  });
 
   NotificationService buildService() => NotificationService(
     messaging: messaging,
     localNotificationsPlugin: localNotificationsPlugin,
     localService: localService,
   );
+
+  /// `logout()` only removes the server-side session for a token the service
+  /// has already resolved, so prime the private token field first.
+  Future<NotificationService> buildServiceWithToken() async {
+    final service = buildService();
+    await service.getToken();
+    return service;
+  }
+
+  void stubMobileSession(MobileSessionInfo? session) => when(
+    () => userApi.getMobileSession(xMobileToken: any(named: 'xMobileToken')),
+  ).thenAnswer((_) async => response<MobileSessionInfo>(session));
+
+  void verifyMobileSessionSaved(String token) => verify(
+    () => userApi.saveMobileSession(
+      xMobileToken: token,
+      mobileSessionInfo: any(named: 'mobileSessionInfo'),
+    ),
+  ).called(1);
 
   setUp(() {
     messaging = MockFirebaseMessaging();
@@ -40,17 +99,64 @@ void main() {
     localDatabase = MockLocalDatabaseService();
     firebaseService = MockFirebaseService();
     userApi = MockUserControllerApi();
+    tokenRefreshes = StreamController<String>.broadcast();
+    addTearDown(tokenRefreshes.close);
 
+    final notificationApi = MockNotificationControllerApi();
     final tbClient = MockThingsboardClient();
     when(() => tbClient.getUserControllerApi()).thenReturn(userApi);
+    when(
+      () => tbClient.getNotificationControllerApi(),
+    ).thenReturn(notificationApi);
+    when(
+      () => notificationApi.getUnreadNotificationsCount(
+        deliveryMethod: any(named: 'deliveryMethod'),
+      ),
+    ).thenAnswer((_) async => response<int>(0));
     when(() => firebaseService.apps).thenReturn(['[DEFAULT]']);
+
+    when(() => messaging.getToken()).thenAnswer((_) async => fcmToken);
     when(() => messaging.deleteToken()).thenAnswer((_) async {});
     when(() => messaging.setAutoInitEnabled(any())).thenAnswer((_) async {});
+    when(() => messaging.getInitialMessage()).thenAnswer((_) async => null);
+    when(
+      () => messaging.requestPermission(provisional: true),
+    ).thenAnswer((_) async => permission(AuthorizationStatus.authorized));
+    when(
+      () => messaging.onTokenRefresh,
+    ).thenAnswer((_) => tokenRefreshes.stream);
+
+    when(
+      () => localNotificationsPlugin.initialize(
+        any(),
+        onDidReceiveNotificationResponse: any(
+          named: 'onDidReceiveNotificationResponse',
+        ),
+      ),
+    ).thenAnswer((_) async => true);
     when(() => localNotificationsPlugin.cancelAll()).thenAnswer((_) async {});
     when(
       () => localService.clearNotificationBadgeCount(),
     ).thenAnswer((_) async {});
+    when(
+      () => localService.updateNotificationsCount(any()),
+    ).thenAnswer((_) async {});
+
+    when(() => localDatabase.isPushRegistered()).thenAnswer((_) async => false);
+    when(() => localDatabase.setPushRegistered()).thenAnswer((_) async {});
     when(() => localDatabase.clearPushRegistered()).thenAnswer((_) async {});
+
+    stubMobileSession(null);
+    when(
+      () => userApi.saveMobileSession(
+        xMobileToken: any(named: 'xMobileToken'),
+        mobileSessionInfo: any(named: 'mobileSessionInfo'),
+      ),
+    ).thenAnswer((_) async => response<void>());
+    when(
+      () =>
+          userApi.removeMobileSession(xMobileToken: any(named: 'xMobileToken')),
+    ).thenAnswer((_) async => response<void>());
 
     registerTestDependencies(
       tbClient: tbClient,
@@ -59,14 +165,164 @@ void main() {
     );
   });
 
-  tearDown(resetTestDependencies);
+  group('NotificationService.init', () {
+    test('skips entirely when Firebase is not configured', () async {
+      when(() => firebaseService.apps).thenReturn(const []);
+
+      await buildService().init();
+
+      verifyNever(() => messaging.getToken());
+      verifyNever(() => localDatabase.setPushRegistered());
+    });
+
+    test('registers the device and marks push as registered when the '
+        'server has no session for the token', () async {
+      await buildService().init();
+
+      verifyMobileSessionSaved(fcmToken);
+      verify(() => localDatabase.setPushRegistered()).called(1);
+    });
+
+    test('marks push as registered without re-saving a fresh '
+        'server-side session', () async {
+      stubMobileSession(sessionRegistered(const Duration(days: 1)));
+
+      await buildService().init();
+
+      verifyNever(
+        () => userApi.saveMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+          mobileSessionInfo: any(named: 'mobileSessionInfo'),
+        ),
+      );
+      verify(() => localDatabase.setPushRegistered()).called(1);
+    });
+
+    test('rotates a token older than 30 days and marks push as '
+        'registered', () async {
+      stubMobileSession(sessionRegistered(const Duration(days: 31)));
+      final tokens = [fcmToken, refreshedToken];
+      when(
+        () => messaging.getToken(),
+      ).thenAnswer((_) async => tokens.removeAt(0));
+
+      await buildService().init();
+
+      verifyInOrder([
+        () => userApi.removeMobileSession(xMobileToken: fcmToken),
+        () => messaging.deleteToken(),
+        () => userApi.saveMobileSession(
+          xMobileToken: refreshedToken,
+          mobileSessionInfo: any(named: 'mobileSessionInfo'),
+        ),
+      ]);
+      verify(() => localDatabase.setPushRegistered()).called(1);
+    });
+
+    test('does not mark push as registered when no FCM token is '
+        'available', () async {
+      when(() => messaging.getToken()).thenThrow(Exception('offline'));
+
+      await buildService().init();
+
+      verifyNever(
+        () =>
+            userApi.getMobileSession(xMobileToken: any(named: 'xMobileToken')),
+      );
+      verifyNever(() => localDatabase.setPushRegistered());
+    });
+
+    test('does not register the device when notification permission '
+        'is denied', () async {
+      when(
+        () => messaging.requestPermission(provisional: true),
+      ).thenAnswer((_) async => permission(AuthorizationStatus.denied));
+
+      await buildService().init();
+
+      verifyNever(() => messaging.getToken());
+      verifyNever(() => localDatabase.setPushRegistered());
+    });
+
+    test('waits for a pending stale cleanup, so the token it registers '
+        'is not the one being deleted', () async {
+      when(
+        () => localDatabase.isPushRegistered(),
+      ).thenAnswer((_) async => true);
+      final deleteToken = Completer<void>();
+      when(() => messaging.deleteToken()).thenAnswer((_) => deleteToken.future);
+      final service = buildService();
+
+      final cleanup = service.cleanUpStalePushRegistration();
+      final init = service.init();
+      await pumpEventQueue();
+      verifyNever(() => messaging.getToken());
+
+      deleteToken.complete();
+      await Future.wait([cleanup, init]);
+
+      verifyInOrder([
+        () => localDatabase.clearPushRegistered(),
+        () => messaging.getToken(),
+        () => localDatabase.setPushRegistered(),
+      ]);
+    });
+  });
+
+  group('NotificationService token refresh', () {
+    test('moves the mobile session to the refreshed token', () async {
+      await buildService().init();
+
+      tokenRefreshes.add(refreshedToken);
+      await pumpEventQueue();
+
+      verifyInOrder([
+        () => userApi.removeMobileSession(xMobileToken: fcmToken),
+        () => userApi.saveMobileSession(
+          xMobileToken: refreshedToken,
+          mobileSessionInfo: any(named: 'mobileSessionInfo'),
+        ),
+      ]);
+    });
+
+    test('registers the refreshed token when the initial token could not '
+        'be obtained', () async {
+      when(() => messaging.getToken()).thenThrow(Exception('offline'));
+      await buildService().init();
+
+      tokenRefreshes.add(refreshedToken);
+      await pumpEventQueue();
+
+      verifyNever(
+        () => userApi.removeMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+        ),
+      );
+      verifyMobileSessionSaved(refreshedToken);
+      verify(() => localDatabase.setPushRegistered()).called(1);
+    });
+
+    test('still saves the refreshed token when removing the previous '
+        'session fails', () async {
+      when(
+        () => userApi.removeMobileSession(
+          xMobileToken: any(named: 'xMobileToken'),
+        ),
+      ).thenThrow(Exception('401'));
+      await buildService().init();
+
+      tokenRefreshes.add(refreshedToken);
+      await pumpEventQueue();
+
+      verifyMobileSessionSaved(refreshedToken);
+    });
+  });
 
   group('NotificationService.cleanUpStalePushRegistration', () {
     test('skips entirely when Firebase is not configured', () async {
       when(() => firebaseService.apps).thenReturn(const []);
-      final service = buildService();
 
-      await service.cleanUpStalePushRegistration();
+      await buildService().cleanUpStalePushRegistration();
 
       verifyNever(() => localDatabase.isPushRegistered());
       verifyNever(() => messaging.deleteToken());
@@ -75,12 +331,7 @@ void main() {
     test(
       'does nothing when push notifications were never registered',
       () async {
-        when(
-          () => localDatabase.isPushRegistered(),
-        ).thenAnswer((_) async => false);
-        final service = buildService();
-
-        await service.cleanUpStalePushRegistration();
+        await buildService().cleanUpStalePushRegistration();
 
         verify(() => localDatabase.isPushRegistered()).called(1);
         verifyNever(() => messaging.deleteToken());
@@ -93,9 +344,8 @@ void main() {
       when(
         () => localDatabase.isPushRegistered(),
       ).thenAnswer((_) async => true);
-      final service = buildService();
 
-      await service.cleanUpStalePushRegistration();
+      await buildService().cleanUpStalePushRegistration();
 
       verify(() => messaging.deleteToken()).called(1);
       verify(() => messaging.setAutoInitEnabled(false)).called(1);
@@ -115,42 +365,44 @@ void main() {
         () => localDatabase.isPushRegistered(),
       ).thenAnswer((_) async => true);
       when(() => messaging.deleteToken()).thenThrow(Exception('no network'));
-      final service = buildService();
 
-      await service.cleanUpStalePushRegistration();
+      await buildService().cleanUpStalePushRegistration();
 
       verifyNever(() => localDatabase.clearPushRegistered());
+    });
+
+    test('runs a single teardown for concurrent calls', () async {
+      when(
+        () => localDatabase.isPushRegistered(),
+      ).thenAnswer((_) async => true);
+      final service = buildService();
+
+      await Future.wait([
+        service.cleanUpStalePushRegistration(),
+        service.cleanUpStalePushRegistration(),
+      ]);
+
+      verify(() => messaging.deleteToken()).called(1);
     });
   });
 
   group('NotificationService.logout', () {
-    Response<void> emptyResponse() =>
-        Response<void>(requestOptions: RequestOptions());
-
     test('skips entirely when Firebase is not configured', () async {
       when(() => firebaseService.apps).thenReturn(const []);
-      final service = buildService();
 
-      await service.logout();
+      await buildService().logout();
 
       verifyNever(() => messaging.deleteToken());
     });
 
     test('removes the mobile session and cleans up the local '
         'registration', () async {
-      when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
-      when(
-        () => userApi.removeMobileSession(
-          xMobileToken: any(named: 'xMobileToken'),
-        ),
-      ).thenAnswer((_) async => emptyResponse());
-      final service = buildService();
-      await service.getToken();
+      final service = await buildServiceWithToken();
 
       await service.logout();
 
       verify(
-        () => userApi.removeMobileSession(xMobileToken: 'fcm-token'),
+        () => userApi.removeMobileSession(xMobileToken: fcmToken),
       ).called(1);
       verify(() => messaging.deleteToken()).called(1);
       verify(() => localDatabase.clearPushRegistered()).called(1);
@@ -158,14 +410,12 @@ void main() {
 
     test('still cleans up when removeMobileSession fails '
         '(e.g. the JWT already expired)', () async {
-      when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
       when(
         () => userApi.removeMobileSession(
           xMobileToken: any(named: 'xMobileToken'),
         ),
       ).thenThrow(Exception('401'));
-      final service = buildService();
-      await service.getToken();
+      final service = await buildServiceWithToken();
 
       await service.logout();
 
@@ -173,15 +423,18 @@ void main() {
       verify(() => localDatabase.clearPushRegistered()).called(1);
     });
 
+    test('completes when the local teardown fails (e.g. offline) and keeps '
+        'the registration flag for the next launch', () async {
+      when(() => messaging.deleteToken()).thenThrow(Exception('no network'));
+      final service = await buildServiceWithToken();
+
+      await expectLater(service.logout(), completes);
+
+      verifyNever(() => localDatabase.clearPushRegistered());
+    });
+
     test('does not reuse the deleted FCM token on a repeated logout', () async {
-      when(() => messaging.getToken()).thenAnswer((_) async => 'fcm-token');
-      when(
-        () => userApi.removeMobileSession(
-          xMobileToken: any(named: 'xMobileToken'),
-        ),
-      ).thenAnswer((_) async => emptyResponse());
-      final service = buildService();
-      await service.getToken();
+      final service = await buildServiceWithToken();
 
       await service.logout();
       await service.logout();


### PR DESCRIPTION
Fixes thingsboard/flutter_thingsboard_pe_app#304

## Problem

When the session ends without an explicit logout (refresh token expires while the app is unused), the FCM token stays registered on the platform and the device keeps receiving alarm push notifications after the automatic logout.

## Solution

- Persist a push-registration flag (`DatabaseKeys.pushNotificationsRegistered`, accessed via `ILocalDatabaseService`) whenever the FCM token is registered with the platform — on a fresh `saveMobileSession` and when `init()` finds an existing valid session (covers installs upgrading to this version).
- New `NotificationService.cleanUpStalePushRegistration()`: if the flag is set, runs the local push teardown (`_cleanupPushRegistration()`, shared with `logout()`) and clears the flag last, so an interrupted cleanup is retried on the next launch. Deleting the local FCM token is what actually stops delivery — the JWT is already invalid at this point, so the server-side `removeMobileSession` cannot succeed and is not attempted on this path; subsequent pushes to the deleted token bounce with `UNREGISTERED` and the platform purges the mobile session on the next delivery attempt.
- `Login.handleUserLoaded()` fires the cleanup (fire-and-forget, after setting the login state) whenever it detects an unauthenticated client. Because the trigger is the persisted flag (not the in-memory login state), it works on cold start — the main reported scenario (app killed, token expired days ago) — as well as when the expiry happens while the app is running. It is a no-op on fresh installs, after manual logout, and on subsequent logged-out launches. `main()` now awaits Firebase initialization, so the single-shot trigger cannot race it.
- The Firebase-configured guard lives inside `NotificationService` (`init()`/`logout()`/`cleanUpStalePushRegistration()` early-return when no Firebase app is initialized) instead of being copied at each call site.
- All `removeMobileSession` calls are awaited inside try/catch (logout, token-refresh listener, `_resetToken`): previously they were fire-and-forget and produced unhandled async errors exactly in the expired-token case; the refresh listener also no longer skips saving the new token when removing the old session fails.

## Limitations

- Pushes delivered between the token expiry and the next app launch cannot be stopped from the client — closing that gap requires a platform-side change (tying mobile session lifetime to the auth session), which is being discussed separately.
- On a custom endpoint (QR login to a different host), Firebase is intentionally not initialized, so a stale registration left by a previous default-endpoint session cannot be cleaned up while connected there. The flag persists and the cleanup runs on the next launch back on the default endpoint; `deleteToken()` is impossible without a Firebase app, so this cannot be closed client-side.

## Testing

- Unit tests drive the real `cleanUpStalePushRegistration()`/`logout()` paths against injectable Firebase collaborators (`test/utils/services/notification_service_test.dart`): flag-gated no-op, full teardown, interrupted-cleanup retry, `removeMobileSession` failure tolerance, and no reuse of a deleted token on repeated logout.
- `test/utils/services/local_database_service_test.dart` pins the persisted key contract (`push_notifications_registered`) with literal-string assertions.
- Shared locator bootstrap for tests in `test/helpers/test_dependencies.dart`.
- `flutter analyze` — no new findings on touched files; manual verification of the cold-start expiry scenario, interrupted-cleanup retry, and the logout/re-login regressions.
