### PR TITLE
fix(dashboard): display dashboard images configured via external URL link

### DIFF
--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -115,20 +115,20 @@ abstract class Utils {
           semanticLabel: semanticLabel,
           onError: onError,
         );
-      } else if (_isBase64DataImageUrl(imageUrl)) {
+      } else if (_isBase64DataImageUrl(newImageUrl)) {
         return _imageFromBase64(
           context,
-          imageUrl,
+          newImageUrl,
           color: color,
           width: width,
           height: height,
           semanticLabel: semanticLabel,
           onError: onError,
         );
-      } else if (_isValidUrl(imageUrl)) {
+      } else if (_isValidUrl(newImageUrl)) {
         return _networkImage(
           context,
-          imageUrl,
+          newImageUrl,
           color: color,
           width: width,
           height: height,

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -298,7 +298,7 @@ abstract class Utils {
     return _imagesUrlRegexp.hasMatch(url);
   }
 
-  /// Absolute links are fetched as they are. Links relative to the platform,
+  /// HTTP(S) links are fetched as they are. Links relative to the platform,
   /// such as an image public link, are resolved against the active endpoint the
   /// same way a browser resolves them against its origin. Anything else has no
   /// meaningful target and is rendered as a missing image.

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -85,8 +85,8 @@ abstract class Utils {
         onError: onError,
       );
     } else {
-      final newImageUrl = _removeTbImagePrefix(imageUrl);
-      if (_isImageResourceUrl(newImageUrl)) {
+      final resolvedImageUrl = _removeTbImagePrefix(imageUrl);
+      if (_isImageResourceUrl(resolvedImageUrl)) {
         final jwtToken = tbClient.getJwtToken();
         if (jwtToken == null) {
           return _onErrorImage(
@@ -98,7 +98,7 @@ abstract class Utils {
             onError: onError,
           );
         }
-        final parts = newImageUrl.split('/');
+        final parts = resolvedImageUrl.split('/');
         final key = parts[parts.length - 1];
         parts[parts.length - 1] = Uri.encodeComponent(key);
         final encodedUrl = parts.join('/');
@@ -115,20 +115,10 @@ abstract class Utils {
           semanticLabel: semanticLabel,
           onError: onError,
         );
-      } else if (_isBase64DataImageUrl(newImageUrl)) {
+      } else if (_isBase64DataImageUrl(resolvedImageUrl)) {
         return _imageFromBase64(
           context,
-          newImageUrl,
-          color: color,
-          width: width,
-          height: height,
-          semanticLabel: semanticLabel,
-          onError: onError,
-        );
-      } else if (_isValidUrl(newImageUrl)) {
-        return _networkImage(
-          context,
-          newImageUrl,
+          resolvedImageUrl,
           color: color,
           width: width,
           height: height,
@@ -136,8 +126,20 @@ abstract class Utils {
           onError: onError,
         );
       } else {
-        return _onErrorImage(
+        final imageLink = _resolveNetworkImageLink(resolvedImageUrl);
+        if (imageLink == null) {
+          return _onErrorImage(
+            context,
+            color: color,
+            width: width,
+            height: height,
+            semanticLabel: semanticLabel,
+            onError: onError,
+          );
+        }
+        return _networkImage(
           context,
+          imageLink,
           color: color,
           width: width,
           height: height,
@@ -287,15 +289,31 @@ abstract class Utils {
   }
 
   static String _removeTbImagePrefix(String url) {
-    return url.replaceFirst(_tbImagePrefix, '');
+    return url.startsWith(_tbImagePrefix)
+        ? url.substring(_tbImagePrefix.length)
+        : url;
   }
 
   static bool _isImageResourceUrl(String url) {
     return _imagesUrlRegexp.hasMatch(url);
   }
 
-  static bool _isValidUrl(String url) {
-    return Uri.tryParse(url) != null;
+  /// Absolute links are fetched as they are. Links relative to the platform,
+  /// such as an image public link, are resolved against the active endpoint the
+  /// same way a browser resolves them against its origin. Anything else has no
+  /// meaningful target and is rendered as a missing image.
+  static String? _resolveNetworkImageLink(String url) {
+    final uri = Uri.tryParse(url);
+    if (uri == null) {
+      return null;
+    }
+    if (uri.scheme == 'http' || uri.scheme == 'https') {
+      return url;
+    }
+    if (!uri.hasScheme && url.startsWith('/')) {
+      return getIt<IEndpointService>().getCachedEndpoint() + url;
+    }
+    return null;
   }
 
   static double degreesToRadians(double degrees) {

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -299,9 +299,9 @@ abstract class Utils {
   }
 
   /// HTTP(S) links are fetched as they are. Links relative to the platform,
-  /// such as an image public link, are resolved against the active endpoint the
-  /// same way a browser resolves them against its origin. Anything else has no
-  /// meaningful target and is rendered as a missing image.
+  /// such as an image public link, are resolved against the active endpoint.
+  /// Anything else has no meaningful target and is rendered as a missing
+  /// image.
   static String? _resolveNetworkImageLink(String url) {
     final uri = Uri.tryParse(url);
     if (uri == null) {

--- a/lib/utils/utils.dart
+++ b/lib/utils/utils.dart
@@ -298,10 +298,9 @@ abstract class Utils {
     return _imagesUrlRegexp.hasMatch(url);
   }
 
-  /// HTTP(S) links are fetched as they are. Links relative to the platform,
-  /// such as an image public link, are resolved against the active endpoint.
-  /// Anything else has no meaningful target and is rendered as a missing
-  /// image.
+  /// HTTP(S) links are fetched as they are. Root-relative links, such as an
+  /// image public link, are resolved against the active endpoint. Anything
+  /// else has no meaningful target and is rendered as a missing image.
   static String? _resolveNetworkImageLink(String url) {
     final uri = Uri.tryParse(url);
     if (uri == null) {


### PR DESCRIPTION
## Summary

Dashboard cards on the Home grid showed an empty white box instead of the thumbnail when the dashboard image was configured via the "Image link" field. Images uploaded to the Image Gallery displayed fine.

Fixes PROD-8502.

Two distinct inputs produced the same empty box, and both are fixed here:

1. **An external web URL** — `https://example.com/pic.png`
2. **An image public link copied from the gallery** — `/api/images/public/{key}`, found while reviewing (1) and reproduced on a device

## Root cause

The platform stores every dashboard image value with a `tb-image;` prefix, external URLs included (`prependTbImagePrefix` in `gallery-image-input.component.ts`). `Utils.imageFromTbImage` computed the prefix-stripped URL but only used it in the gallery-resource branch, while the base64 and external-URL branches checked and loaded the raw prefixed string. `Uri.tryParse('tb-image;https://…')` returns `null`, so external links fell through to the error placeholder — a transparent 1×1 GIF stretched by the card's `FittedBox`, which renders as the empty white box.

The public-link case has a separate cause. `TbResourceInfo.getPublicLink()` returns a **relative** path, the "Embed image" dialog hands users exactly that string, and the "Image link" field has no validators. `IMAGES_URL_REGEXP` matches only `tenant|system`, so a public link is classified as external, and `_isValidUrl` — which was just `Uri.tryParse(url) != null` and therefore true for almost any string — let the relative path reach `Image.network`, where it cannot be fetched at all (`ArgumentError: No host specified in URI`).

## Changes

- Use the prefix-stripped URL in every branch, and rename it to `resolvedImageUrl` to match `ImageService.resolveImageUrl` on the web side.
- Anchor the `tb-image;` strip with `startsWith`/`substring` instead of `replaceFirst`, so an occurrence inside a link is no longer removed.
- Replace `_isValidUrl` with `_resolveNetworkImageLink`, which classifies and resolves in one step: absolute `http`/`https` links are fetched as they are, platform-relative links resolve against the active endpoint the way a browser resolves them against its origin, and anything without a meaningful target renders the missing image. Resolved relative links carry no auth header, matching the platform — `/api/images/public/{key}` is a `noauth` endpoint and a browser `<img src>` does not send the JWT either.

Since `imageFromTbImage` also backs device and device-profile images, this repairs image links there too, not only the dashboard grid.

## Behaviour

| Value in "Image link" | Result |
| --- | --- |
| `https://example.com/pic.png` | fetched as is |
| `tb-image;https://example.com/pic.png` | prefix stripped, fetched |
| `/api/images/tenant/pic.png` | endpoint + path, with auth header |
| `/api/images/public/pic.png` | endpoint + path, no auth header |
| `data:image/png;base64,…` | decoded in memory |
| `ftp://…`, or text that is not a link | missing image placeholder |

## Test plan

- [ ] Dashboard image set via an external URL → thumbnail displays on the Home grid
- [ ] Dashboard image set to an image public link copied from the gallery Embed dialog → thumbnail displays
- [ ] Dashboard image uploaded to the Image Gallery → still displays
- [ ] Dashboard without an image → placeholder icon still displays
- [ ] Device and device profile images still display
