### PR TITLE
fix: users logged out despite a valid refresh token

### DIFF
--- a/lib/core/context/tb_context.dart
+++ b/lib/core/context/tb_context.dart
@@ -118,20 +118,11 @@ class TbContext implements PopEntry {
   }
 
   Future<void> onFatalError(dynamic e) async {
-    String getMessage(dynamic e, BuildContext context) {
-      final message =
-          e is ThingsboardError
-              ? e.translatedMessage(context)
-              : S.of(context).unknownError;
-
-      return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
-    }
-
     await _overlayService.showAlertDialog(
       content:
           (context) => DialogContent(
             title: S.of(context).fatalError,
-            message: getMessage(e, context),
+            message: translatedFatalErrorMessage(context, e),
             ok: S.of(context).cancel,
           ),
     );

--- a/lib/core/context/tb_context.dart
+++ b/lib/core/context/tb_context.dart
@@ -18,6 +18,7 @@ import 'package:thingsboard_app/utils/services/endpoint/i_endpoint_service.dart'
 import 'package:thingsboard_app/utils/services/firebase/i_firebase_service.dart';
 import 'package:thingsboard_app/utils/services/notification_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
+import 'package:thingsboard_app/utils/translation_utils.dart';
 import 'package:thingsboard_app/utils/utils.dart';
 import 'package:universal_platform/universal_platform.dart';
 
@@ -120,7 +121,7 @@ class TbContext implements PopEntry {
     String getMessage(dynamic e, BuildContext context) {
       final message =
           e is ThingsboardError
-              ? (e.message ?? S.of(context).unknownError)
+              ? e.translatedMessage(context)
               : S.of(context).unknownError;
 
       return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
@@ -139,7 +140,7 @@ class TbContext implements PopEntry {
 
   void onError(ThingsboardError tbError) {
     log.error('onError', tbError, tbError.getStackTrace());
-    _overlayService.showErrorNotification((_) => tbError.message!);
+    _overlayService.showErrorNotification(tbError.translatedMessage);
   }
 
   void onLoadStarted() {

--- a/lib/core/context/tb_context.dart
+++ b/lib/core/context/tb_context.dart
@@ -119,19 +119,14 @@ class TbContext implements PopEntry {
 
   Future<void> onFatalError(dynamic e) async {
     await _overlayService.showAlertDialog(
-      content:
-          (context) => DialogContent(
-            title: S.of(context).fatalError,
-            message: translatedFatalErrorMessage(context, e),
-            ok: S.of(context).cancel,
-          ),
+      content: (context) => fatalErrorDialogContent(context, e),
     );
     logout();
   }
 
   void onError(ThingsboardError tbError) {
     log.error('onError', tbError, tbError.getStackTrace());
-    _overlayService.showErrorNotification(tbError.translatedMessage);
+    _overlayService.showErrorNotification(tbError.getTranslatedMessage);
   }
 
   void onLoadStarted() {

--- a/lib/utils/providers/error_provider/error_provider.dart
+++ b/lib/utils/providers/error_provider/error_provider.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:thingsboard_app/core/auth/login/provider/login_provider.dart';
 import 'package:thingsboard_app/core/logger/tb_logger.dart';
@@ -23,21 +22,12 @@ class Error extends _$Error {
     _overlayService.showErrorNotification(tbError.translatedMessage);
   }
 
-  String _getMessage(dynamic e, BuildContext context) {
-    final message =
-        e is ThingsboardError
-            ? e.translatedMessage(context)
-            : S.of(context).unknownError;
-
-    return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
-  }
-
   Future<void> onFatalError(dynamic e) async {
     await _overlayService.showAlertDialog(
       content:
           (context) => DialogContent(
             title: S.of(context).fatalError,
-            message: _getMessage(e, context),
+            message: translatedFatalErrorMessage(context, e),
             ok: S.of(context).cancel,
           ),
     );

--- a/lib/utils/providers/error_provider/error_provider.dart
+++ b/lib/utils/providers/error_provider/error_provider.dart
@@ -6,6 +6,7 @@ import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
+import 'package:thingsboard_app/utils/translation_utils.dart';
 part 'error_provider.g.dart';
 
 @riverpod
@@ -19,17 +20,18 @@ class Error extends _$Error {
 
   void onError(ThingsboardError tbError) {
     _log.error('onError', tbError, tbError.getStackTrace());
-    _overlayService.showErrorNotification((_) => tbError.message!);
+    _overlayService.showErrorNotification(tbError.translatedMessage);
   }
 
   String _getMessage(dynamic e, BuildContext context) {
     final message =
         e is ThingsboardError
-            ? (e.message ?? S.of(context).unknownError)
+            ? e.translatedMessage(context)
             : S.of(context).unknownError;
 
     return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
   }
+
   Future<void> onFatalError(dynamic e) async {
     await _overlayService.showAlertDialog(
       content:

--- a/lib/utils/providers/error_provider/error_provider.dart
+++ b/lib/utils/providers/error_provider/error_provider.dart
@@ -1,7 +1,6 @@
 import 'package:riverpod_annotation/riverpod_annotation.dart';
 import 'package:thingsboard_app/core/auth/login/provider/login_provider.dart';
 import 'package:thingsboard_app/core/logger/tb_logger.dart';
-import 'package:thingsboard_app/generated/l10n.dart';
 import 'package:thingsboard_app/locator.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
@@ -19,17 +18,12 @@ class Error extends _$Error {
 
   void onError(ThingsboardError tbError) {
     _log.error('onError', tbError, tbError.getStackTrace());
-    _overlayService.showErrorNotification(tbError.translatedMessage);
+    _overlayService.showErrorNotification(tbError.getTranslatedMessage);
   }
 
   Future<void> onFatalError(dynamic e) async {
     await _overlayService.showAlertDialog(
-      content:
-          (context) => DialogContent(
-            title: S.of(context).fatalError,
-            message: translatedFatalErrorMessage(context, e),
-            ok: S.of(context).cancel,
-          ),
+      content: (context) => fatalErrorDialogContent(context, e),
     );
     ref.read(loginProvider.notifier).logout();
   }

--- a/lib/utils/services/tb_client_service/tb_client_service.dart
+++ b/lib/utils/services/tb_client_service/tb_client_service.dart
@@ -10,6 +10,7 @@ import 'package:thingsboard_app/utils/services/endpoint/i_endpoint_service.dart'
 import 'package:thingsboard_app/utils/services/loading_service/i_loading_service.dart';
 import 'package:thingsboard_app/utils/services/overlay_service/i_overlay_service.dart';
 import 'package:thingsboard_app/utils/services/tb_client_service/i_tb_client_service.dart';
+import 'package:thingsboard_app/utils/translation_utils.dart';
 import 'package:thingsboard_app/utils/utils.dart';
 import 'package:thingsboard_app/thingsboard_client.dart';
 
@@ -57,7 +58,7 @@ class TbClientService implements ITbClientService {
   String _getMessage(dynamic e, BuildContext context) {
     final message =
         e is ThingsboardError
-            ? (e.message ?? S.of(context).unknownError)
+            ? e.translatedMessage(context)
             : S.of(context).unknownError;
 
     return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
@@ -88,9 +89,7 @@ class TbClientService implements ITbClientService {
 
         return;
       }
-      _overlayService.showErrorNotification(
-        (context) => e.message ?? S.of(context).unknownError,
-      );
+      _overlayService.showErrorNotification(e.translatedMessage);
     });
   }
 

--- a/lib/utils/services/tb_client_service/tb_client_service.dart
+++ b/lib/utils/services/tb_client_service/tb_client_service.dart
@@ -55,21 +55,12 @@ class TbClientService implements ITbClientService {
     getIt<ICommunicationService>().fire(const UserLoadedEvent());
   }
 
-  String _getMessage(dynamic e, BuildContext context) {
-    final message =
-        e is ThingsboardError
-            ? e.translatedMessage(context)
-            : S.of(context).unknownError;
-
-    return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
-  }
-
   void onInitError(dynamic e) {
     _overlayService.showAlertDialog(
       content:
           (context) => DialogContent(
             title: S.of(context).fatalError,
-            message: _getMessage(e, context),
+            message: translatedFatalErrorMessage(context, e),
             ok: S.of(context).cancel,
           ),
     );

--- a/lib/utils/services/tb_client_service/tb_client_service.dart
+++ b/lib/utils/services/tb_client_service/tb_client_service.dart
@@ -88,7 +88,9 @@ class TbClientService implements ITbClientService {
 
         return;
       }
-      _overlayService.showErrorNotification((_) => e.message!);
+      _overlayService.showErrorNotification(
+        (context) => e.message ?? S.of(context).unknownError,
+      );
     });
   }
 

--- a/lib/utils/services/tb_client_service/tb_client_service.dart
+++ b/lib/utils/services/tb_client_service/tb_client_service.dart
@@ -57,12 +57,7 @@ class TbClientService implements ITbClientService {
 
   void onInitError(dynamic e) {
     _overlayService.showAlertDialog(
-      content:
-          (context) => DialogContent(
-            title: S.of(context).fatalError,
-            message: translatedFatalErrorMessage(context, e),
-            ok: S.of(context).cancel,
-          ),
+      content: (context) => fatalErrorDialogContent(context, e),
     );
   }
 
@@ -80,7 +75,7 @@ class TbClientService implements ITbClientService {
 
         return;
       }
-      _overlayService.showErrorNotification(e.translatedMessage);
+      _overlayService.showErrorNotification(e.getTranslatedMessage);
     });
   }
 

--- a/lib/utils/translation_utils.dart
+++ b/lib/utils/translation_utils.dart
@@ -171,5 +171,14 @@ extension ThingsboardErrorTranslation on ThingsboardError {
       message ?? S.of(context).unknownError;
 }
 
+String translatedFatalErrorMessage(BuildContext context, Object? error) {
+  final message =
+      error is ThingsboardError
+          ? error.translatedMessage(context)
+          : S.of(context).unknownError;
+
+  return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
+}
+
 typedef TranslationBuilder = String Function(BuildContext context);
 typedef TranslatedDialogBuilder = DialogContent Function(BuildContext context);

--- a/lib/utils/translation_utils.dart
+++ b/lib/utils/translation_utils.dart
@@ -166,5 +166,10 @@ extension ActionTypeTranslationUtils on ActionType {
   }
 }
 
+extension ThingsboardErrorTranslation on ThingsboardError {
+  String translatedMessage(BuildContext context) =>
+      message ?? S.of(context).unknownError;
+}
+
 typedef TranslationBuilder = String Function(BuildContext context);
 typedef TranslatedDialogBuilder = DialogContent Function(BuildContext context);

--- a/lib/utils/translation_utils.dart
+++ b/lib/utils/translation_utils.dart
@@ -166,18 +166,28 @@ extension ActionTypeTranslationUtils on ActionType {
   }
 }
 
-extension ThingsboardErrorTranslation on ThingsboardError {
-  String translatedMessage(BuildContext context) =>
-      message ?? S.of(context).unknownError;
+extension ThingsboardErrorTranslationUtils on ThingsboardError {
+  /// App-wide fallback text for a message-less [ThingsboardError]; the wording
+  /// mirrors the client's own "Unknown error" literal in `parseMessage`.
+  String getTranslatedMessage(BuildContext context) {
+    final message = this.message;
+    return message == null || message.isEmpty
+        ? S.of(context).unknownError
+        : message;
+  }
 }
 
-String translatedFatalErrorMessage(BuildContext context, Object? error) {
+DialogContent fatalErrorDialogContent(BuildContext context, Object? error) {
   final message =
       error is ThingsboardError
-          ? error.translatedMessage(context)
+          ? error.getTranslatedMessage(context)
           : S.of(context).unknownError;
 
-  return '${S.of(context).fatalApplicationErrorOccurred}\n$message';
+  return DialogContent(
+    title: S.of(context).fatalError,
+    message: '${S.of(context).fatalApplicationErrorOccurred}\n$message',
+    ok: S.of(context).cancel,
+  );
 }
 
 typedef TranslationBuilder = String Function(BuildContext context);


### PR DESCRIPTION
## Context (PROD-8704)

The customer-facing bug — users logged out after a long idle despite a valid refresh token — is fixed in the **dart client**: thingsboard/thingsboard-dart-client#6 (the client cleared the session on any transport-failed token refresh).

## This PR (app-side)

A small crash guard surfaced while reproducing the issue on device: `TbClientService.onClientError` force-unwrapped `ThingsboardError.message`, throwing `Null check operator used on a null value` on an offline cold start when the client reports an error whose message is null.

- `onClientError` now falls back to the localized `unknownError`, matching the existing `_getMessage` pattern in the same file.

CE change; merges to PE. Verified on device (Pixel 6): 0 null-check crashes on the offline-resume path that previously produced them.